### PR TITLE
fix: bucket policy 404

### DIFF
--- a/components/buckets/info.vue
+++ b/components/buckets/info.vue
@@ -351,8 +351,13 @@ const getbucketPolicy = async () => {
     } else {
       bucketPolicy.value = 'public';
     }
-  } catch (error) {
-    // console.error("Error fetching bucket policy:", error)
+  } catch (error: any) {
+    // Handle 404 error when no policy exists
+    console.error("Error fetching bucket policy:", error);
+    // Set default values for private policy
+    bucketPolicy.value = 'private';
+    policyFormValue.value.policy = 'private';
+    policyFormValue.value.content = '{}';
   }
 };
 


### PR DESCRIPTION
If the bucket policy API return 404 (or any other error being catch), display the bucket policy as 'private' and content as '{}'