### PR TITLE
fix: copy button in firefox

### DIFF
--- a/components/copy-input.vue
+++ b/components/copy-input.vue
@@ -34,6 +34,10 @@ clipboard.on('success', function(e) {
 
 // 这里成功的时候也响应error，所以这里也加上
 clipboard.on('error', function(e) {
+  // 如果复制失败，则使用navigator.clipboard.writeText进行复制
+  if (navigator.clipboard) {
+    navigator.clipboard.writeText(model.value || '');
+  }
   message.success(t('Copy Success'));
 });
 onUnmounted(() => {


### PR DESCRIPTION
Copy button not working in firefox (but works in chrome). So I suggest using navigator.clipboard as fallback.