### PR TITLE
fix(ui): show Change Password only for users with consoleAdmin

### DIFF
--- a/components/user/dropdown.tsx
+++ b/components/user/dropdown.tsx
@@ -18,7 +18,7 @@ export function UserDropdown() {
   const { t } = useTranslation()
   const router = useRouter()
   const { logout, isAdmin, setIsAdmin } = useAuth()
-  const { userInfo } = usePermissions()
+  const { userInfo, canChangePassword } = usePermissions()
   const { isAdminUser } = useUsers()
   const { state } = useSidebar()
   const isCollapsed = state === "collapsed"
@@ -68,7 +68,7 @@ export function UserDropdown() {
               <span>{(userInfo as { account_name?: string })?.account_name ?? (isAdmin ? "rustfsAdmin" : "")}</span>
             </div>
           </DropdownMenuItem>
-          {!isAdmin && (
+          {canChangePassword && (
             <DropdownMenuItem onSelect={handleChangePassword}>
               <RiLockPasswordLine className="h-4 w-4" />
               <span>{t("Change Password")}</span>

--- a/hooks/use-permissions.tsx
+++ b/hooks/use-permissions.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useState, useCallback, useEffect, useMemo } from "react"
 import { hasConsoleScopes, type ConsolePolicy } from "@/lib/console-policy-parser"
-import { PAGE_PERMISSIONS } from "@/lib/console-permissions"
+import { CONSOLE_SCOPES, PAGE_PERMISSIONS } from "@/lib/console-permissions"
 import { useAuth } from "@/contexts/auth-context"
 import { useApiOptional } from "@/contexts/api-context"
 
@@ -15,6 +15,8 @@ interface PermissionsContextValue {
   hasPermission: (action: string | string[], matchAll?: boolean) => boolean
   canAccessPath: (path: string) => boolean
   isAdmin: boolean
+  /** True when user has consoleAdmin (or is admin). Only these users can change password per RustFS backend. */
+  canChangePassword: boolean
 }
 
 const PermissionsContext = createContext<PermissionsContextValue | null>(null)
@@ -92,6 +94,8 @@ export function PermissionsProvider({ children }: { children: React.ReactNode })
     }
   }, [api, isAuthenticated, isAdmin, hasFetchedPolicy, isLoading, fetchUserPolicy])
 
+  const canChangePassword = isAdmin || hasPermission(CONSOLE_SCOPES.CONSOLE_ADMIN)
+
   const value = useMemo(
     () => ({
       userPolicy,
@@ -102,8 +106,9 @@ export function PermissionsProvider({ children }: { children: React.ReactNode })
       hasPermission,
       canAccessPath,
       isAdmin,
+      canChangePassword,
     }),
-    [userPolicy, userInfo, isLoading, hasFetchedPolicy, fetchUserPolicy, hasPermission, canAccessPath, isAdmin],
+    [userPolicy, userInfo, isLoading, hasFetchedPolicy, fetchUserPolicy, hasPermission, canAccessPath, isAdmin, canChangePassword],
   )
 
   return <PermissionsContext.Provider value={value}>{children}</PermissionsContext.Provider>


### PR DESCRIPTION
Align with RustFS backend: only users with consoleAdmin policy can change password (see rustfs/rustfs#1923). Add canChangePassword to permissions (isAdmin or has consoleAdmin scope) and show the menu item only when true, so non-admin users no longer see the option and get 403 on submit.

Made-with: Cursor

# Pull Request

## Description

<!-- Briefly describe the purpose and content of this PR -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Security fix

## Testing

<!-- Describe how you tested these changes -->

- [ ] Unit tests added/updated
- [ ] Manual testing completed

```bash
pnpm test:run
```

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review completed
- [ ] TypeScript types are properly defined
- [ ] All commit messages are in English (Conventional Commits)
- [ ] All existing tests pass
- [ ] No new dependencies added, or they are justified

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Additional Notes

<!-- Any other context -->
