### PR TITLE
feat(oidc): add roles claim field to provider settings

### DIFF
--- a/app/(dashboard)/oidc/page.tsx
+++ b/app/(dashboard)/oidc/page.tsx
@@ -39,6 +39,7 @@ function providerToFormValues(provider: OidcConfigProvider): OidcProviderFormVal
     claim_prefix: provider.claim_prefix,
     role_policy: provider.role_policy,
     groups_claim: provider.groups_claim,
+    roles_claim: provider.roles_claim ?? "",
     email_claim: provider.email_claim,
     username_claim: provider.username_claim,
   }
@@ -130,6 +131,7 @@ function buildSavePayload(values: OidcProviderFormValues): SaveOidcConfigPayload
     claim_prefix: trimOrEmpty(values.claim_prefix),
     role_policy: trimOrEmpty(values.role_policy),
     groups_claim: trimOrEmpty(values.groups_claim),
+    roles_claim: trimOrEmpty(values.roles_claim),
     email_claim: trimOrEmpty(values.email_claim),
     username_claim: trimOrEmpty(values.username_claim),
   }

--- a/components/oidc/form.tsx
+++ b/components/oidc/form.tsx
@@ -341,6 +341,22 @@ export function OidcForm({
         </Field>
 
         <Field>
+          <FieldLabel htmlFor="roles_claim">{t("Roles Claim")}</FieldLabel>
+          <FieldContent>
+            <Input
+              id="roles_claim"
+              value={values.roles_claim}
+              onChange={(event) => onChange("roles_claim", event.target.value)}
+              placeholder="roles"
+              disabled={isReadOnly}
+            />
+          </FieldContent>
+          <FieldDescription>
+            {t("Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.")}
+          </FieldDescription>
+        </Field>
+
+        <Field>
           <FieldLabel htmlFor="email_claim">{t("Email Claim")}</FieldLabel>
           <FieldContent>
             <Input

--- a/i18n/locales/ar-MA.json
+++ b/i18n/locales/ar-MA.json
@@ -1059,6 +1059,8 @@
   "Failed to save OIDC provider": "فشل حفظ موفر OIDC",
   "Failed to validate OIDC configuration": "فشل التحقق من إعدادات OIDC",
   "Groups Claim": "مطالبة المجموعات",
+  "Roles Claim": "Roles Claim",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.",
   "Issuer": "الجهة المصدّرة",
   "Leave empty to keep current secret": "اتركه فارغًا للاحتفاظ بالسر الحالي",
   "Loading...": "جارٍ التحميل...",

--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -1072,6 +1072,8 @@
   "Failed to save OIDC provider": "OIDC-Anbieter konnte nicht gespeichert werden",
   "Failed to validate OIDC configuration": "OIDC-Konfiguration konnte nicht validiert werden",
   "Groups Claim": "Gruppen-Claim",
+  "Roles Claim": "Roles Claim",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.",
   "Issuer": "Aussteller",
   "Leave empty to keep current secret": "Leer lassen, um das aktuelle Secret beizubehalten",
   "Loading...": "Wird geladen...",

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -930,6 +930,8 @@
   "Failed to save OIDC provider": "Failed to save OIDC provider",
   "Failed to validate OIDC configuration": "Failed to validate OIDC configuration",
   "Groups Claim": "Groups Claim",
+  "Roles Claim": "Roles Claim",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.",
   "Issuer": "Issuer",
   "Leave empty to keep current secret": "Leave empty to keep current secret",
   "Loading...": "Loading...",

--- a/i18n/locales/es-ES.json
+++ b/i18n/locales/es-ES.json
@@ -1081,6 +1081,8 @@
   "Failed to save OIDC provider": "No se pudo guardar el proveedor OIDC",
   "Failed to validate OIDC configuration": "No se pudo validar la configuración OIDC",
   "Groups Claim": "Claim de grupos",
+  "Roles Claim": "Roles Claim",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.",
   "Issuer": "Emisor",
   "Leave empty to keep current secret": "Déjelo vacío para conservar el secreto actual",
   "Loading...": "Cargando...",

--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -1083,6 +1083,8 @@
   "Failed to save OIDC provider": "Échec de l'enregistrement du fournisseur OIDC",
   "Failed to validate OIDC configuration": "Échec de la validation de la configuration OIDC",
   "Groups Claim": "Claim des groupes",
+  "Roles Claim": "Roles Claim",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.",
   "Issuer": "Émetteur",
   "Leave empty to keep current secret": "Laissez vide pour conserver le secret actuel",
   "Loading...": "Chargement...",

--- a/i18n/locales/id-ID.json
+++ b/i18n/locales/id-ID.json
@@ -1081,6 +1081,8 @@
   "Failed to save OIDC provider": "Gagal menyimpan penyedia OIDC",
   "Failed to validate OIDC configuration": "Gagal memvalidasi konfigurasi OIDC",
   "Groups Claim": "Claim Grup",
+  "Roles Claim": "Roles Claim",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.",
   "Issuer": "Penerbit",
   "Leave empty to keep current secret": "Biarkan kosong untuk mempertahankan secret saat ini",
   "Loading...": "Memuat...",

--- a/i18n/locales/it-IT.json
+++ b/i18n/locales/it-IT.json
@@ -1082,6 +1082,8 @@
   "Failed to save OIDC provider": "Impossibile salvare il provider OIDC",
   "Failed to validate OIDC configuration": "Impossibile validare la configurazione OIDC",
   "Groups Claim": "Claim gruppi",
+  "Roles Claim": "Roles Claim",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.",
   "Issuer": "Issuer",
   "Leave empty to keep current secret": "Lascia vuoto per mantenere il segreto corrente",
   "Loading...": "Caricamento...",

--- a/i18n/locales/ja-JP.json
+++ b/i18n/locales/ja-JP.json
@@ -1078,6 +1078,8 @@
   "Failed to save OIDC provider": "OIDC プロバイダーの保存に失敗しました",
   "Failed to validate OIDC configuration": "OIDC 設定の検証に失敗しました",
   "Groups Claim": "グループクレーム",
+  "Roles Claim": "Roles Claim",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.",
   "Issuer": "発行者",
   "Leave empty to keep current secret": "現在のシークレットを維持するには空欄のままにしてください",
   "Loading...": "読み込み中...",

--- a/i18n/locales/ko-KR.json
+++ b/i18n/locales/ko-KR.json
@@ -1078,6 +1078,8 @@
   "Failed to save OIDC provider": "OIDC 공급자 저장에 실패했습니다",
   "Failed to validate OIDC configuration": "OIDC 구성 검증에 실패했습니다",
   "Groups Claim": "그룹 클레임",
+  "Roles Claim": "Roles Claim",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.",
   "Issuer": "발급자",
   "Leave empty to keep current secret": "현재 시크릿을 유지하려면 비워 두세요",
   "Loading...": "불러오는 중...",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1082,6 +1082,8 @@
   "Failed to save OIDC provider": "Falha ao salvar provedor OIDC",
   "Failed to validate OIDC configuration": "Falha ao validar a configuração OIDC",
   "Groups Claim": "Claim de grupos",
+  "Roles Claim": "Roles Claim",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.",
   "Issuer": "Emissor",
   "Leave empty to keep current secret": "Deixe em branco para manter o segredo atual",
   "Loading...": "Carregando...",

--- a/i18n/locales/ru-RU.json
+++ b/i18n/locales/ru-RU.json
@@ -1083,6 +1083,8 @@
   "Failed to save OIDC provider": "Не удалось сохранить OIDC-провайдера",
   "Failed to validate OIDC configuration": "Не удалось проверить конфигурацию OIDC",
   "Groups Claim": "Claim групп",
+  "Roles Claim": "Roles Claim",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.",
   "Issuer": "Издатель",
   "Leave empty to keep current secret": "Оставьте пустым, чтобы сохранить текущий секрет",
   "Loading...": "Загрузка...",

--- a/i18n/locales/tr-TR.json
+++ b/i18n/locales/tr-TR.json
@@ -1074,6 +1074,8 @@
   "Failed to save OIDC provider": "OIDC sağlayıcısı kaydedilemedi",
   "Failed to validate OIDC configuration": "OIDC yapılandırması doğrulanamadı",
   "Groups Claim": "Gruplar Claim",
+  "Roles Claim": "Roles Claim",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.",
   "Issuer": "Yayıncı",
   "Leave empty to keep current secret": "Geçerli sırrı korumak için boş bırakın",
   "Loading...": "Yükleniyor...",

--- a/i18n/locales/vi-VN.json
+++ b/i18n/locales/vi-VN.json
@@ -1059,6 +1059,8 @@
   "Failed to save OIDC provider": "Lưu nhà cung cấp OIDC thất bại",
   "Failed to validate OIDC configuration": "Xác thực cấu hình OIDC thất bại",
   "Groups Claim": "Claim nhóm",
+  "Roles Claim": "Roles Claim",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.",
   "Issuer": "Nhà phát hành",
   "Leave empty to keep current secret": "Để trống để giữ secret hiện tại",
   "Loading...": "Đang tải...",

--- a/i18n/locales/zh-CN.json
+++ b/i18n/locales/zh-CN.json
@@ -937,6 +937,8 @@
   "Failed to save OIDC provider": "保存 OIDC provider 失败",
   "Failed to validate OIDC configuration": "OIDC 配置校验失败",
   "Groups Claim": "分组声明",
+  "Roles Claim": "角色声明",
+  "Optional. Separate claim for role values (e.g. roles). Leave empty to use groups claim only.": "可选。角色值的独立声明名（例如 roles）。留空则仅使用分组声明。",
   "Issuer": "签发者",
   "Leave empty to keep current secret": "留空表示保留当前密钥",
   "Loading...": "加载中...",

--- a/types/oidc.ts
+++ b/types/oidc.ts
@@ -16,6 +16,8 @@ export interface OidcConfigProvider {
   claim_prefix: string
   role_policy: string
   groups_claim: string
+  /** Secondary claim for role values (e.g. Entra `roles`). Omitted by older servers. */
+  roles_claim?: string
   email_claim: string
   username_claim: string
 }
@@ -38,6 +40,7 @@ export interface SaveOidcConfigPayload {
   claim_prefix: string
   role_policy: string
   groups_claim: string
+  roles_claim: string
   email_claim: string
   username_claim: string
 }
@@ -86,6 +89,7 @@ export interface OidcProviderFormValues {
   claim_prefix: string
   role_policy: string
   groups_claim: string
+  roles_claim: string
   email_claim: string
   username_claim: string
 }
@@ -106,6 +110,7 @@ export const DEFAULT_OIDC_FORM_VALUES: OidcProviderFormValues = {
   claim_prefix: "",
   role_policy: "",
   groups_claim: "groups",
+  roles_claim: "",
   email_claim: "email",
   username_claim: "preferred_username",
 }


### PR DESCRIPTION
# Pull Request

## Description

Adds **Roles claim** (`roles_claim`) to the OIDC provider form and API payload so the Console stays aligned with RustFS admin API. Loading and saving now includes `roles_claim`, preventing saves from clearing a previously configured value on the server.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Security fix

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed

```bash
pnpm exec eslint types/oidc.ts "app/(dashboard)/oidc/page.tsx" components/oidc/form.tsx
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [ ] All existing tests pass (full `tsc` may report existing Next.js `.next` type issues in this environment)
- [x] No new dependencies added, or they are justified

## Related Issues

Closes #

## Screenshots (if applicable)

N/A

## Additional Notes

Pairs with RustFS server support for `roles_claim` on OIDC provider config. i18n: full strings for `en-US` and `zh-CN`; other locales include English placeholders for the new keys.
