### PR TITLE
fix(console): show OIDC account name for console admin users

### DIFF
--- a/components/user/dropdown.tsx
+++ b/components/user/dropdown.tsx
@@ -91,7 +91,7 @@ export function UserDropdown() {
           <DropdownMenuItem asChild>
             <div className="flex cursor-default items-center gap-2">
               <RiUserLine className="h-4 w-4" />
-              <span>{(userInfo as { account_name?: string })?.account_name ?? (isAdmin ? "rustfsAdmin" : "")}</span>
+              <span>{(userInfo as { account_name?: string })?.account_name ?? ""}</span>
             </div>
           </DropdownMenuItem>
           {!isAdmin && (

--- a/hooks/use-permissions.tsx
+++ b/hooks/use-permissions.tsx
@@ -126,10 +126,10 @@ export function PermissionsProvider({ children }: { children: React.ReactNode })
   }, [api, isAuthenticated, hasResolvedAdmin, fetchAdminStatus])
 
   useEffect(() => {
-    if (api && isAuthenticated && hasResolvedAdmin && !isAdmin && !hasFetchedPolicy && !isLoading) {
+    if (api && isAuthenticated && hasResolvedAdmin && !hasFetchedPolicy && !isLoading) {
       fetchUserPolicy()
     }
-  }, [api, isAuthenticated, hasResolvedAdmin, isAdmin, hasFetchedPolicy, isLoading, fetchUserPolicy])
+  }, [api, isAuthenticated, hasResolvedAdmin, hasFetchedPolicy, isLoading, fetchUserPolicy])
 
   const canChangePassword = isAdmin || hasPermission(CONSOLE_SCOPES.CONSOLE_ADMIN)
 


### PR DESCRIPTION
## Description

This PR fixes the user dropdown showing the hardcoded label `rustfsAdmin` for OIDC users who have the `consoleAdmin` policy (and are treated as console administrators). The console previously skipped fetching `/accountinfo` for admin sessions and substituted a placeholder name.

Changes:
- **PermissionsProvider**: fetch user policy/account info whenever the user is authenticated and admin resolution is complete, not only for non-admin users.
- **UserDropdown**: display `account_name` from the API without the `rustfsAdmin` fallback (empty string when missing).

This aligns the UI with the API, which returns the OIDC session identity (e.g. `preferred_username`) for temporary credentials.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Security fix

## Testing

- [ ] Unit tests added/updated (no test runner configured in this repo)
- [x] Manual testing completed

```bash
pnpm install --frozen-lockfile
rm -rf .next && pnpm exec tsc --noEmit
pnpm lint
```

Note: `pnpm test:run` is not defined in `package.json`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass (no test script in project)
- [x] No new dependencies added, or they are justified

## Related Issues

Closes rustfs/rustfs#2612 (console-side; server already returns `account_name` from OIDC `parent_user` for temp sessions).

## Screenshots (if applicable)

N/A (username text in user menu).

## Additional Notes

Upstream issue: https://github.com/rustfs/rustfs/issues/2612
