### PR TITLE
fix: run dropdown menu item actions

### DIFF
--- a/app/(dashboard)/site-replication/page.tsx
+++ b/app/(dashboard)/site-replication/page.tsx
@@ -365,26 +365,26 @@ export default function SiteReplicationPage() {
               <DropdownMenuContent align="end">
                 <DropdownMenuLabel>{peer.name || t("Peer site")}</DropdownMenuLabel>
                 {canManageSites ? (
-                  <DropdownMenuItem onSelect={() => setEditingPeer(peer)}>
+                  <DropdownMenuItem onClick={() => setEditingPeer(peer)}>
                     <RiArrowLeftRightLine className="size-4" aria-hidden />
                     {t("Edit Site")}
                   </DropdownMenuItem>
                 ) : null}
                 {canResyncSites ? (
-                  <DropdownMenuItem onSelect={() => void handleResync(peer, "start")}>
+                  <DropdownMenuItem onClick={() => void handleResync(peer, "start")}>
                     <RiRestartLine className="size-4" aria-hidden />
                     {t("Start Resync")}
                   </DropdownMenuItem>
                 ) : null}
                 {canResyncSites ? (
-                  <DropdownMenuItem onSelect={() => void handleResync(peer, "cancel")}>
+                  <DropdownMenuItem onClick={() => void handleResync(peer, "cancel")}>
                     <RiRefreshLine className="size-4" aria-hidden />
                     {t("Cancel Resync")}
                   </DropdownMenuItem>
                 ) : null}
                 {canRemoveSites ? <DropdownMenuSeparator /> : null}
                 {canRemoveSites ? (
-                  <DropdownMenuItem variant="destructive" onSelect={() => confirmRemoveSite(peer)}>
+                  <DropdownMenuItem variant="destructive" onClick={() => confirmRemoveSite(peer)}>
                     <RiDeleteBin5Line className="size-4" aria-hidden />
                     {t("Remove Site")}
                   </DropdownMenuItem>

--- a/components/language-switcher.tsx
+++ b/components/language-switcher.tsx
@@ -46,7 +46,7 @@ export function LanguageSwitcher() {
       />
       <DropdownMenuContent className="w-40" align="start">
         {options.map(({ label, key }) => (
-          <DropdownMenuItem key={key} onSelect={() => i18n.changeLanguage(key)}>
+          <DropdownMenuItem key={key} onClick={() => i18n.changeLanguage(key)}>
             {label}
           </DropdownMenuItem>
         ))}

--- a/components/theme-switcher.tsx
+++ b/components/theme-switcher.tsx
@@ -35,7 +35,7 @@ export function ThemeSwitcher() {
       />
       <DropdownMenuContent className="w-40" align="start">
         {themeOptions.map(({ labelKey, key, Icon: OptionIcon }) => (
-          <DropdownMenuItem key={key} onSelect={() => setTheme(key)}>
+          <DropdownMenuItem key={key} onClick={() => setTheme(key)}>
             <OptionIcon className="me-2 h-4 w-4" />
             {t(labelKey)}
           </DropdownMenuItem>

--- a/components/user/dropdown.tsx
+++ b/components/user/dropdown.tsx
@@ -101,12 +101,12 @@ export function UserDropdown() {
             }
           />
           {!isAdmin && (
-            <DropdownMenuItem onSelect={handleChangePassword}>
+            <DropdownMenuItem onClick={handleChangePassword}>
               <RiLockPasswordLine className="h-4 w-4" />
               <span>{t("Change Password")}</span>
             </DropdownMenuItem>
           )}
-          <DropdownMenuItem onSelect={handleLogout}>
+          <DropdownMenuItem onClick={handleLogout}>
             <RiLogoutBoxRLine className="h-4 w-4" />
             <span>{t("Logout")}</span>
           </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- Replace Radix-style `onSelect` handlers on Base UI `DropdownMenuItem` with `onClick` so selected menu actions actually run.
- Fix language switching, theme switching, user menu actions, and site replication action menu items.

## Test Plan
- [x] `source ~/.nvm/nvm.sh && nvm use v22 && pnpm tsc --noEmit`
- [x] `source ~/.nvm/nvm.sh && nvm use v22 && pnpm lint`
- [x] `source ~/.nvm/nvm.sh && nvm use v22 && pnpm prettier --check components/language-switcher.tsx components/theme-switcher.tsx components/user/dropdown.tsx app/(dashboard)/site-replication/page.tsx`
- [x] `curl -L -s -o /tmp/events-after-menu-fix.html -w '%{http_code}' http://localhost:3000/rustfs/console/events/` returned 200
