### PR TITLE
fix: remove redundant function call when delete replication config

### DIFF
--- a/components/buckets/replication-tab.tsx
+++ b/components/buckets/replication-tab.tsx
@@ -32,8 +32,7 @@ export function BucketReplicationTab({ bucketName, hideTitle = false }: BucketRe
   const message = useMessage()
   const dialog = useDialog()
   const { canCapability } = usePermissions()
-  const { getBucketReplication, putBucketReplication, deleteBucketReplication, deleteRemoteReplicationTarget } =
-    useBucket()
+  const { getBucketReplication, putBucketReplication, deleteBucketReplication } = useBucket()
   const replicationContext = React.useMemo(() => ({ bucket: bucketName }), [bucketName])
   const canEditReplication = canCapability("bucket.replication.edit", replicationContext)
 
@@ -65,7 +64,6 @@ export function BucketReplicationTab({ bucketName, hideTitle = false }: BucketRe
       try {
         if (remaining.length === 0) {
           await deleteBucketReplication(bucketName)
-          await deleteRemoteReplicationTarget(bucketName, rule.Destination?.Bucket ?? "")
         } else {
           const currentConfig = await getBucketReplication(bucketName)
           const role = currentConfig?.ReplicationConfiguration?.Role
@@ -88,7 +86,6 @@ export function BucketReplicationTab({ bucketName, hideTitle = false }: BucketRe
       data,
       deleteBucketReplication,
       bucketName,
-      deleteRemoteReplicationTarget,
       getBucketReplication,
       putBucketReplication,
       message,


### PR DESCRIPTION
# Pull Request

## Description

<!-- Briefly describe the purpose and content of this PR -->
When deleting the last replication rule, the first API call (`DeleteBucketReplication`) already removes the `ReplicationTarget` on the backend.

The frontend then made a second delete call (`remove-remote-target`) for the same target, which could return an error.  
Although the replication config was actually deleted successfully, this error message could mislead users into thinking the delete operation failed, and users had to refresh to see the correct state.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Security fix

## Testing

<!-- Describe how you tested these changes -->

- [ ] Unit tests added/updated
- [x] Manual testing completed

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [ ] TypeScript types are properly defined
- [ ] All commit messages are in English (Conventional Commits)
- [ ] All existing tests pass
- [ ] No new dependencies added, or they are justified
