### PR TITLE
fix(access-keys): format policy JSON, validate input, and decode XML error messages

### DIFF
--- a/components/access-keys/edit-item.tsx
+++ b/components/access-keys/edit-item.tsx
@@ -41,6 +41,8 @@ export function AccessKeysEditItem({ open, onOpenChange, row, onSuccess }: Acces
   const [description, setDescription] = React.useState("")
   const [status, setStatus] = React.useState<"on" | "off">("on")
   const [submitting, setSubmitting] = React.useState(false)
+  const [initialName, setInitialName] = React.useState("")
+  const [initialDescription, setInitialDescription] = React.useState("")
 
   const minExpiry = React.useMemo(() => dayjs().toISOString(), [])
 
@@ -56,13 +58,26 @@ export function AccessKeysEditItem({ open, onOpenChange, row, onSuccess }: Acces
             accountStatus?: string
           }) => {
             setAccesskey(row.accessKey)
-            const policyValue = typeof res.policy === "string" ? res.policy : JSON.stringify(res.policy ?? {}, null, 2)
+            let policyValue: string
+            if (typeof res.policy === "string") {
+              try {
+                policyValue = JSON.stringify(JSON.parse(res.policy), null, 2)
+              } catch {
+                policyValue = res.policy
+              }
+            } else {
+              policyValue = JSON.stringify(res.policy ?? {}, null, 2)
+            }
             setPolicy(policyValue)
             setExpiry(
               res.expiration && res.expiration !== "9999-01-01T00:00:00Z" ? dayjs(res.expiration).toISOString() : null,
             )
-            setName(res.name ?? "")
-            setDescription(res.description ?? "")
+            const initialNameValue = res.name ?? ""
+            const initialDescriptionValue = res.description ?? ""
+            setName(initialNameValue)
+            setDescription(initialDescriptionValue)
+            setInitialName(initialNameValue)
+            setInitialDescription(initialDescriptionValue)
             setStatus((res.accountStatus as "on" | "off") ?? "on")
           },
         )
@@ -79,15 +94,41 @@ export function AccessKeysEditItem({ open, onOpenChange, row, onSuccess }: Acces
   const submitForm = async () => {
     if (!accesskey) return
 
+    // Validate policy JSON format before submitting
+    if (policy) {
+      try {
+        const parsed = JSON.parse(policy)
+        // Basic structure validation
+        if (typeof parsed !== "object" || parsed === null) {
+          message.error(t("Policy must be a valid JSON object"))
+          return
+        }
+        if (parsed.Statement !== undefined && !Array.isArray(parsed.Statement)) {
+          message.error(t("Policy Statement must be an array"))
+          return
+        }
+      } catch {
+        message.error(t("Policy format is invalid. Please check the JSON syntax."))
+        return
+      }
+    }
+
     setSubmitting(true)
     try {
-      await updateServiceAccount(accesskey, {
+      const payload: Record<string, unknown> = {
         newPolicy: policy || "{}",
         newStatus: status,
-        newName: name,
-        newDescription: description,
         newExpiration: expiry ? dayjs(expiry).toISOString() : "9999-01-01T00:00:00Z",
-      })
+      }
+      // Only send newName if it has changed to avoid validation errors on unchanged invalid names
+      if (name !== initialName) {
+        payload.newName = name
+      }
+      // Only send newDescription if it has changed
+      if (description !== initialDescription) {
+        payload.newDescription = description
+      }
+      await updateServiceAccount(accesskey, payload)
       message.success(t("Updated successfully"))
       closeModal()
       onSuccess()

--- a/components/access-keys/edit-item.tsx
+++ b/components/access-keys/edit-item.tsx
@@ -93,7 +93,7 @@ export function AccessKeysEditItem({ open, onOpenChange, row, onSuccess }: Acces
       onSuccess()
     } catch (error) {
       console.error(error)
-      message.error(t("Update failed"))
+      message.error((error as Error)?.message || t("Update failed"))
     } finally {
       setSubmitting(false)
     }

--- a/components/user/edit/access-keys.tsx
+++ b/components/user/edit/access-keys.tsx
@@ -422,7 +422,7 @@ function UserAccessKeysEditDialog({ open, onOpenChange, userName, row, onSuccess
       onSuccess()
     } catch (error) {
       console.error(error)
-      message.error(t("Update failed"))
+      message.error((error as Error)?.message || t("Update failed"))
     } finally {
       setSubmitting(false)
     }

--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -31,6 +31,43 @@ export const getXmlErrorMessage = (xml: string): string | null => {
     return null
   }
 
+  // Use DOMParser for proper XML parsing with automatic entity decoding
+  if (typeof DOMParser !== "undefined") {
+    try {
+      const parser = new DOMParser()
+      const doc = parser.parseFromString(trimmed, "text/xml")
+      
+      // Check for parse errors
+      const parseError = doc.querySelector("parsererror")
+      if (parseError) {
+        return null
+      }
+      
+      // Try to extract Message first (most specific)
+      const message = doc.querySelector("Message")?.textContent?.trim()
+      if (message && !GENERIC_ERROR_MESSAGES.has(message.toLowerCase())) {
+        return message
+      }
+      
+      // Fall back to Code
+      const code = doc.querySelector("Code")?.textContent?.trim()
+      if (code && !GENERIC_ERROR_MESSAGES.has(code.toLowerCase())) {
+        return code
+      }
+      
+      // Fall back to Error element text
+      const error = doc.querySelector("Error")?.textContent?.trim()
+      if (error && !GENERIC_ERROR_MESSAGES.has(error.toLowerCase())) {
+        return error
+      }
+      
+      return message || code || error || null
+    } catch {
+      // Fall through to regex-based parsing
+    }
+  }
+
+  // Fallback: regex-based parsing (for SSR or if DOMParser fails)
   const message = getXmlTagText(trimmed, "Message")
   if (isSpecificErrorText(message)) {
     return message


### PR DESCRIPTION
## Description

Fixes two related issues in the Access Keys policy editor:

### Issue #3233 — Policy JSON not formatted

The policy JSON was displayed as a single-line compact string, making it difficult to read and edit. Now the policy is formatted with 2-space indentation when loaded into the editor.

### Issue #3232 — Error messages not shown to users

When saving an invalid policy, users only saw "Update Failed" instead of the actual error from the server. The root cause was that XML error responses containing HTML entities (e.g. `&quot;`) were not being decoded. Now uses `DOMParser` for proper XML parsing with automatic entity decoding.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Manual testing completed

```bash
pnpm tsc --noEmit
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] No new dependencies added

## Related Issues

Closes rustfs/rustfs#3233
Closes rustfs/rustfs#3232

## Changes

### `components/access-keys/edit-item.tsx`
- Format policy JSON with `JSON.stringify(parsed, null, 2)` when loading from API
- Add client-side JSON validation before submit (syntax check + structure check)
- Track initial name/description values; only send `newName`/`newDescription` when changed (avoids validation errors on legacy data with non-conforming names)

### `lib/error-handler.ts`
- Use `DOMParser` for XML error parsing — automatically decodes HTML entities (`&quot;` → `"`, `&lt;` → `<`, etc.)
- Falls back to regex-based parsing for SSR environments

## Additional Notes

Companion backend PR: rustfs/rustfs#3237 (formats policy JSON server-side and improves error messages)