### PR TITLE
ci: use pnpm 11 instead of 11.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  PNPM_VERSION: "11.4"
+  PNPM_VERSION: "11"
   NODE_VERSION: "22"
 
 jobs:
@@ -64,7 +64,7 @@ jobs:
               zip -r ../artifacts/${{ github.event.release.tag_name }}/rustfs-console-${{ github.event.release.tag_name }}.zip .
             )
           fi
-          
+
       - uses: actions/upload-artifact@v7
         name: Upload artifacts
         with:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -18,7 +18,7 @@ on:
           - all
 
 env:
-  PNPM_VERSION: "11.4"
+  PNPM_VERSION: "11"
   NODE_VERSION: "22"
 
 jobs:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,7 +10,7 @@ on:
     - cron: "0 2 * * *"
 
 env:
-  PNPM_VERSION: "11.4"
+  PNPM_VERSION: "11"
   NODE_VERSION: "22"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
         type: string
 
 env:
-  PNPM_VERSION: "11.4"
+  PNPM_VERSION: "11"
   NODE_VERSION: "22"
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PNPM_VERSION: "11.4"
+  PNPM_VERSION: "11"
   NODE_VERSION: "22"
 
 jobs:


### PR DESCRIPTION
Use PNPM 11.x in CI, as vulnerabilities are frequently found in PNPM these days.

# Pull Request

## Description

<!-- Briefly describe the purpose and content of this PR -->

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [x] Security fix

## Testing

<!-- Describe how you tested these changes -->

- [ ] Unit tests added/updated
- [ ] Manual testing completed

```bash
pnpm test:run
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [ ] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [ ] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

Closes #

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Additional Notes

<!-- Any other context -->
