### PR TITLE
fix: guard object preview fullscreen on webkit

### DIFF
--- a/components/object/preview-modal.tsx
+++ b/components/object/preview-modal.tsx
@@ -42,6 +42,15 @@ interface ObjectPreviewModalProps {
   } | null
 }
 
+type FullscreenDocument = Document & {
+  webkitExitFullscreen?: () => Promise<void> | void
+  webkitFullscreenElement?: Element | null
+}
+
+type FullscreenElement = HTMLElement & {
+  webkitRequestFullscreen?: () => Promise<void> | void
+}
+
 function normalizeContentType(contentType: string) {
   return contentType.split(";")[0]?.trim().toLowerCase() ?? ""
 }
@@ -76,6 +85,34 @@ function isParquetPreview(contentType: string, objectKey: string) {
   const keyLower = objectKey.toLowerCase()
   if (PARQUET_MIMES.includes(contentType)) return true
   return PARQUET_EXTENSIONS.some((ext) => keyLower.endsWith(ext))
+}
+
+function getFullscreenElement(doc: FullscreenDocument): Element | null {
+  return doc.fullscreenElement ?? doc.webkitFullscreenElement ?? null
+}
+
+function exitFullscreen(doc: FullscreenDocument): Promise<void> {
+  if (typeof doc.exitFullscreen === "function") {
+    return Promise.resolve(doc.exitFullscreen()).then(() => undefined)
+  }
+
+  if (typeof doc.webkitExitFullscreen === "function") {
+    return Promise.resolve(doc.webkitExitFullscreen()).then(() => undefined)
+  }
+
+  return Promise.resolve()
+}
+
+function requestFullscreen(element: FullscreenElement): Promise<void> {
+  if (typeof element.requestFullscreen === "function") {
+    return Promise.resolve(element.requestFullscreen()).then(() => undefined)
+  }
+
+  if (typeof element.webkitRequestFullscreen === "function") {
+    return Promise.resolve(element.webkitRequestFullscreen()).then(() => undefined)
+  }
+
+  return Promise.resolve()
 }
 
 export function ObjectPreviewModal({ show, onShowChange, object }: ObjectPreviewModalProps) {
@@ -146,7 +183,7 @@ export function ObjectPreviewModal({ show, onShowChange, object }: ObjectPreview
 
   React.useEffect(() => {
     const handleFullscreenChange = () => {
-      setIsImageFullscreen(document.fullscreenElement === imagePreviewRef.current)
+      setIsImageFullscreen(getFullscreenElement(document as FullscreenDocument) === imagePreviewRef.current)
     }
 
     document.addEventListener("fullscreenchange", handleFullscreenChange)
@@ -156,8 +193,10 @@ export function ObjectPreviewModal({ show, onShowChange, object }: ObjectPreview
   }, [])
 
   React.useEffect(() => {
-    if (!show && document.fullscreenElement === imagePreviewRef.current) {
-      void document.exitFullscreen().catch(() => {})
+    const fullscreenDocument = document as FullscreenDocument
+
+    if (!show && getFullscreenElement(fullscreenDocument) === imagePreviewRef.current) {
+      void exitFullscreen(fullscreenDocument).catch(() => {})
     }
     if (!show) {
       setIsImageFullscreen(false)
@@ -184,20 +223,21 @@ export function ObjectPreviewModal({ show, onShowChange, object }: ObjectPreview
   }, [imageNaturalSize])
 
   const toggleImageFullscreen = React.useCallback(() => {
-    const container = imagePreviewRef.current
+    const fullscreenDocument = document as FullscreenDocument
+    const container = imagePreviewRef.current as FullscreenElement | null
     if (!container) return
 
-    if (document.fullscreenElement === container) {
-      void document.exitFullscreen().catch(() => {})
+    if (getFullscreenElement(fullscreenDocument) === container) {
+      void exitFullscreen(fullscreenDocument).catch(() => {})
       return
     }
 
-    if (document.fullscreenElement) {
-      void document.exitFullscreen().catch(() => {})
+    if (getFullscreenElement(fullscreenDocument)) {
+      void exitFullscreen(fullscreenDocument).catch(() => {})
       return
     }
 
-    void container.requestFullscreen().catch(() => {})
+    void requestFullscreen(container).catch(() => {})
   }, [])
 
   React.useLayoutEffect(() => {

--- a/tests/lib/object-preview-source.test.js
+++ b/tests/lib/object-preview-source.test.js
@@ -1,0 +1,15 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+
+test("object preview modal falls back when standard fullscreen APIs are unavailable", () => {
+  const source = fs.readFileSync("components/object/preview-modal.tsx", "utf8")
+
+  assert.equal(source.includes("webkitExitFullscreen"), true)
+  assert.equal(source.includes("webkitRequestFullscreen"), true)
+  assert.equal(source.includes("getFullscreenElement(document as FullscreenDocument)"), true)
+  assert.equal(source.includes("void exitFullscreen(fullscreenDocument).catch(() => {})"), true)
+  assert.equal(source.includes("void requestFullscreen(container).catch(() => {})"), true)
+  assert.equal(source.includes("void document.exitFullscreen().catch(() => {})"), false)
+  assert.equal(source.includes("void container.requestFullscreen().catch(() => {})"), false)
+})


### PR DESCRIPTION
# Pull Request

## Description

Fix the object preview modal fullscreen controls for iOS Safari/WebKit by guarding fullscreen entry/exit behind compatible helpers instead of assuming the standard Fullscreen API is always available.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

```bash
node --test tests/lib/object-preview-source.test.js
./node_modules/.bin/eslint components/object/preview-modal.tsx tests/lib/object-preview-source.test.js
./node_modules/.bin/prettier --check components/object/preview-modal.tsx tests/lib/object-preview-source.test.js
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

Closes #129

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Additional Notes

This PR intentionally only includes the preview modal fullscreen compatibility fix so the WebKit crash can be reviewed independently from broader browser-page hardening changes.