### PR TITLE
fix: restore bucket breadcrumb click navigation

### DIFF
--- a/components/top-nav-breadcrumb.tsx
+++ b/components/top-nav-breadcrumb.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import * as React from "react"
-import Link from "next/link"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { useTranslation } from "react-i18next"
 import {
@@ -99,18 +98,14 @@ export function TopNavBreadcrumb() {
             <BreadcrumbItem>
               {item.href ? (
                 <BreadcrumbLink
-                  render={
-                    <Link
-                      href={item.href}
-                      onClick={(e) => {
-                        e.preventDefault()
-                        if (item.href) router.push(item.href)
-                      }}
-                    >
-                      {item.label}
-                    </Link>
-                  }
-                />
+                  href={item.href}
+                  onClick={(e) => {
+                    e.preventDefault()
+                    router.push(item.href!)
+                  }}
+                >
+                  {item.label}
+                </BreadcrumbLink>
               ) : (
                 <BreadcrumbPage>{item.label}</BreadcrumbPage>
               )}

--- a/tests/lib/top-nav-breadcrumb-source.test.js
+++ b/tests/lib/top-nav-breadcrumb-source.test.js
@@ -1,0 +1,13 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+
+test("top nav breadcrumb handles clicks on the rendered breadcrumb link", () => {
+  const source = fs.readFileSync("components/top-nav-breadcrumb.tsx", "utf8")
+
+  assert.equal(source.includes('import Link from "next/link"'), false)
+  assert.equal(source.includes("<BreadcrumbLink"), true)
+  assert.equal(source.includes("href={item.href}"), true)
+  assert.equal(source.includes("router.push(item.href!)"), true)
+  assert.equal(source.includes("render={"), false)
+})


### PR DESCRIPTION
## Summary
- Render breadcrumb links directly through BreadcrumbLink instead of nesting Next Link via Base UI render.
- Keep breadcrumb clicks routed through router.push so bucket detail pages can return to the bucket list after refresh.
- Add a source regression test to prevent reintroducing the broken composition pattern.

Fixes rustfs/rustfs#3403

## Test Plan
- node --test tests/lib/top-nav-breadcrumb-source.test.js
- COREPACK_ENABLE_PROJECT_SPEC=0 pnpm lint
- COREPACK_ENABLE_PROJECT_SPEC=0 pnpm tsc --noEmit