### PR TITLE
fix: restrict PDF preview to PDF content type

### DIFF
--- a/components/object/preview-modal.tsx
+++ b/components/object/preview-modal.tsx
@@ -76,9 +76,8 @@ function getPreviewMode(hasPreviewUrl: boolean, canRenderText: boolean, canRende
   return canRenderText ? "text" : "sandbox"
 }
 
-function isPdfPreview(contentType: string, objectKey: string) {
-  const keyLower = objectKey.toLowerCase()
-  return contentType === "application/pdf" || keyLower.endsWith(".pdf")
+function isPdfPreview(contentType: string) {
+  return contentType === "application/pdf"
 }
 
 function isParquetPreview(contentType: string, objectKey: string) {
@@ -139,7 +138,7 @@ export function ObjectPreviewModal({ show, onShowChange, object }: ObjectPreview
   const isJson = normalizedContentType === "application/json" || objectKeyLower.endsWith(".json")
   const canRenderText = hasPreviewUrl && isSafeTextPreview(normalizedContentType, objectKey, objectSize)
   const canRenderImage = hasPreviewUrl && isImagePreview(normalizedContentType, objectKey)
-  const canRenderPdf = hasPreviewUrl && isPdfPreview(normalizedContentType, objectKey)
+  const canRenderPdf = hasPreviewUrl && isPdfPreview(normalizedContentType)
   const canRenderParquet = hasPreviewUrl && isParquetPreview(normalizedContentType, objectKey)
   const previewMode: PreviewMode = canRenderParquet
     ? "parquet"

--- a/tests/lib/object-preview-source.test.js
+++ b/tests/lib/object-preview-source.test.js
@@ -13,3 +13,14 @@ test("object preview modal falls back when standard fullscreen APIs are unavaila
   assert.equal(source.includes("void document.exitFullscreen().catch(() => {})"), false)
   assert.equal(source.includes("void container.requestFullscreen().catch(() => {})"), false)
 })
+
+test("object preview modal only uses the PDF viewer for application/pdf content", () => {
+  const source = fs.readFileSync("components/object/preview-modal.tsx", "utf8")
+
+  assert.match(
+    source,
+    /function isPdfPreview\(contentType: string\) \{\s+return contentType === "application\/pdf"\s+\}/,
+  )
+  assert.match(source, /isPdfPreview\(normalizedContentType\)/)
+  assert.doesNotMatch(source, /keyLower\.endsWith\("\.pdf"\)/)
+})


### PR DESCRIPTION
# Pull Request

## Description

Restricts the PDF viewer to objects served as application/pdf so extension-only .pdf matches fall back to the sandboxed preview path.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [x] Security fix

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed

```bash
CI=true pnpm install --frozen-lockfile
node --test tests/lib/object-preview-source.test.js
pnpm lint
pnpm type-check
pnpm format:check
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

None

## Screenshots (if applicable)

None

## Additional Notes

None