### PR TITLE
fix: update tier provider defaults

### DIFF
--- a/app/(dashboard)/tiers/page.tsx
+++ b/app/(dashboard)/tiers/page.tsx
@@ -26,6 +26,10 @@ function getConfig(row: TierRow): TierConfig | undefined {
       return row.s3
     case "aliyun":
       return row.aliyun
+    case "tencent":
+      return row.tencent
+    case "huaweicloud":
+      return row.huaweicloud
     case "azure":
       return row.azure
     case "gcs":

--- a/components/tiers/new-form.tsx
+++ b/components/tiers/new-form.tsx
@@ -20,9 +20,14 @@ interface TiersNewFormProps {
 
 const TYPE_OPTIONS = [
   { labelKey: "RustFS", value: "rustfs", icon: "/logo.svg", descKey: "RustFS built-in cold storage" },
-  { labelKey: "Minio", value: "minio", icon: "/svg/minio.svg", descKey: "External MinIO tier" },
+  { labelKey: "MinIO", value: "minio", icon: "/svg/minio.svg", descKey: "External MinIO tier" },
   { labelKey: "AWS S3", value: "s3", icon: "/svg/aws.svg", descKey: "Standard AWS S3 tier" },
-  { labelKey: "Aliyun OSS", value: "aliyun", icon: "/svg/aliyun.svg", descKey: "Alibaba Cloud Object Storage Service" },
+  {
+    labelKey: "Alibaba Cloud",
+    value: "aliyun",
+    icon: "/svg/aliyun.svg",
+    descKey: "Alibaba Cloud Object Storage Service",
+  },
   { labelKey: "Azure Blob", value: "azure", icon: "/svg/azure.svg", descKey: "Microsoft Azure Blob Storage" },
   { labelKey: "Google Cloud Storage", value: "gcs", icon: "/svg/google.svg", descKey: "Google Cloud Storage" },
   { labelKey: "Cloudflare R2", value: "r2", icon: "/svg/cloudflare.svg", descKey: "Cloudflare R2 Storage" },

--- a/hooks/use-tiers.ts
+++ b/hooks/use-tiers.ts
@@ -18,13 +18,13 @@ export interface TierRow {
   minio?: TierConfig
   s3?: TierConfig
   aliyun?: TierConfig
+  tencent?: TierConfig
+  huaweicloud?: TierConfig
   azure?: TierConfig
   gcs?: TierConfig
   r2?: TierConfig
   [key: string]: unknown
 }
-
-const UNSUPPORTED_TIER_TYPES = new Set(["huaweicloud", "tencent"])
 
 export function useTiers() {
   const api = useApi()
@@ -44,8 +44,7 @@ export function useTiers() {
   )
 
   const listTiers = useCallback(async () => {
-    const tiers = (await api.get("/tier")) as TierRow[] | undefined
-    return (tiers ?? []).filter((tier) => !UNSUPPORTED_TIER_TYPES.has(tier.type))
+    return api.get("/tier") as Promise<TierRow[]>
   }, [api])
 
   const removeTiers = useCallback(

--- a/tests/lib/tier-support-source.test.js
+++ b/tests/lib/tier-support-source.test.js
@@ -2,7 +2,7 @@ import test from "node:test"
 import assert from "node:assert/strict"
 import fs from "node:fs"
 
-test("tier UI no longer offers Huawei or Tencent storage support", () => {
+test("tier picker hides Huawei and Tencent without filtering existing rows", () => {
   const newFormSource = fs.readFileSync("components/tiers/new-form.tsx", "utf8")
   const pageSource = fs.readFileSync("app/(dashboard)/tiers/page.tsx", "utf8")
   const hookSource = fs.readFileSync("hooks/use-tiers.ts", "utf8")
@@ -11,9 +11,13 @@ test("tier UI no longer offers Huawei or Tencent storage support", () => {
   assert.equal(newFormSource.includes("huaweiyun.svg"), false)
   assert.equal(newFormSource.includes("Tencent COS"), false)
   assert.equal(newFormSource.includes("tenxunyun.svg"), false)
-  assert.equal(pageSource.includes("row.huaweicloud"), false)
-  assert.equal(pageSource.includes("row.tencent"), false)
-  assert.equal(hookSource.includes("huaweicloud?: TierConfig"), false)
-  assert.equal(hookSource.includes("tencent?: TierConfig"), false)
-  assert.equal(hookSource.includes('UNSUPPORTED_TIER_TYPES = new Set(["huaweicloud", "tencent"])'), true)
+  assert.equal(newFormSource.includes('labelKey: "Aliyun OSS"'), false)
+  assert.equal(newFormSource.includes('labelKey: "Minio"'), false)
+  assert.equal(newFormSource.includes('labelKey: "Alibaba Cloud"'), true)
+  assert.equal(newFormSource.includes('labelKey: "MinIO"'), true)
+  assert.equal(pageSource.includes("row.huaweicloud"), true)
+  assert.equal(pageSource.includes("row.tencent"), true)
+  assert.equal(hookSource.includes("huaweicloud?: TierConfig"), true)
+  assert.equal(hookSource.includes("tencent?: TierConfig"), true)
+  assert.equal(hookSource.includes("UNSUPPORTED_TIER_TYPES"), false)
 })


### PR DESCRIPTION
Description: hides Huawei OBS and Tencent COS from the tier picker, renames Aliyun OSS to Alibaba Cloud and Minio to MinIO, and keeps existing Tencent/Huawei tier rows readable. Type of Change: Bug fix; Test improvements. Testing: pnpm exec node --test tests/lib/tier-support-source.test.js; pnpm lint; pnpm type-check; pnpm format:check; pnpm build. Checklist: code style checked; self-review completed; TypeScript checked; commit message is Conventional Commits; no new dependencies. Related Issues: N/A. Screenshots: N/A.