### PR TITLE
fix: preserve pool status before rebalance starts

### DIFF
--- a/app/(dashboard)/pool-decommission/page.tsx
+++ b/app/(dashboard)/pool-decommission/page.tsx
@@ -184,6 +184,7 @@ export default function PoolDecommissionPage() {
   const [submitting, setSubmitting] = useState(false)
   const [dataReady, setDataReady] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [rebalanceError, setRebalanceError] = useState<string | null>(null)
   const [selectedPoolId, setSelectedPoolId] = useState("")
   const [overview, setOverview] = useState<PoolsOverview>({
     pools: [] as PoolSummary[],
@@ -216,19 +217,30 @@ export default function PoolDecommissionPage() {
       if (showSpinner) setLoading(true)
       else setRefreshing(true)
       setError(null)
+      setRebalanceError(null)
       try {
-        const [nextOverview, rebalanceStatus, decommissionStatuses] = await Promise.all([
+        const [overviewResult, rebalanceResult, decommissionResult] = await Promise.allSettled([
           getPoolsOverview(),
           getRebalanceStatus(),
           getDecommissionStatuses(),
         ])
         if (!mountedRef.current || requestId !== requestVersionRef.current) return false
-        const nextRebalanceState = deriveRebalanceDisplayState(rebalanceStatus, nextOverview.supportState)
+
+        if (overviewResult.status === "rejected") throw overviewResult.reason
+        if (decommissionResult.status === "rejected") throw decommissionResult.reason
+
+        const nextOverview = overviewResult.value
+        const decommissionStatuses = decommissionResult.value
         const statusEntries = decommissionStatuses.map((status) => [status.poolId, status])
 
         setOverview(nextOverview)
         setStatuses(Object.fromEntries(statusEntries) as Record<string, DecommissionInfo | null>)
-        setRebalanceState(nextRebalanceState)
+        if (rebalanceResult.status === "fulfilled") {
+          setRebalanceState(deriveRebalanceDisplayState(rebalanceResult.value, nextOverview.supportState))
+        } else {
+          setRebalanceState("unknown")
+          setRebalanceError(rebalanceResult.reason instanceof Error ? rebalanceResult.reason.message : t("Load Failed"))
+        }
         setSelectedPoolId((current) =>
           current && nextOverview.pools.some((pool) => pool.id === current)
             ? current
@@ -283,7 +295,8 @@ export default function PoolDecommissionPage() {
   const selectionLocked = isTaskLocked(activeTask)
   const activePoolCount = poolRows.filter((row) => isActivePool(row.pool)).length
   const trackedProgress = trackedTask ? getProgressPercent(trackedTask.status, trackedTask.pool) : 0
-  const interactionLocked = loading || refreshing || submitting || Boolean(error) || !dataReady
+  const interactionLocked =
+    loading || refreshing || submitting || Boolean(error) || Boolean(rebalanceError) || !dataReady
 
   useEffect(() => {
     shouldPollRef.current = dataReady && poolRows.some((row) => shouldPoll(row.displayState))
@@ -515,6 +528,21 @@ export default function PoolDecommissionPage() {
           </Alert>
         ) : null}
 
+        {rebalanceError ? (
+          <Alert variant="destructive">
+            <AlertTitle>
+              {t("Current Rebalance Status")}: {t("Unavailable")}
+            </AlertTitle>
+            <AlertDescription className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <span className="break-words">{rebalanceError}</span>
+              <Button type="button" variant="outline" size="sm" onClick={() => void loadData()}>
+                <RiRefreshLine className="size-4" aria-hidden />
+                {t("Refresh")}
+              </Button>
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
         {initialLoading ? (
           <div className="flex min-h-64 items-center justify-center gap-2 text-sm text-muted-foreground" role="status">
             <Spinner className="size-5" aria-hidden />
@@ -633,7 +661,7 @@ export default function PoolDecommissionPage() {
                 </p>
               </div>
               <Badge variant={selectionLocked ? "outline" : "secondary"}>
-                {!dataReady || error ? t("Unknown") : selectionLocked ? t("Running") : t("Ready")}
+                {!dataReady || error || rebalanceError ? t("Unknown") : selectionLocked ? t("Running") : t("Ready")}
               </Badge>
             </CardHeader>
             <CardContent className="space-y-5">

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,7 @@ const eslintConfig = defineConfig([
     ".nuxt/**",
     "out/**",
     "build/**",
+    ".worktrees/**",
     "next-env.d.ts",
   ]),
   {

--- a/hooks/use-pool-operations.ts
+++ b/hooks/use-pool-operations.ts
@@ -5,6 +5,7 @@ import { useApi } from "@/contexts/api-context"
 import {
   deriveDecommissionDisplayState,
   deriveRebalanceDisplayState,
+  isRebalanceNotStartedError,
   normalizeDecommissionInfo,
   normalizeDecommissionStatus,
   normalizePoolsOverview,
@@ -38,8 +39,15 @@ export function usePoolOperations() {
   }, [api])
 
   const getRebalanceStatus = useCallback(async () => {
-    const response = await api.get("/rebalance/status")
-    return normalizeRebalanceStatus(response)
+    try {
+      const response = await api.get("/rebalance/status")
+      return normalizeRebalanceStatus(response)
+    } catch (error) {
+      if (isRebalanceNotStartedError(error)) {
+        return normalizeRebalanceStatus({ status: "idle" })
+      }
+      throw error
+    }
   }, [api])
 
   const startRebalance = useCallback(async () => {

--- a/lib/pool-operations.ts
+++ b/lib/pool-operations.ts
@@ -473,6 +473,10 @@ function normalizeState(value: string): string {
   return value.trim().toLowerCase()
 }
 
+export function isRebalanceNotStartedError(error: unknown): boolean {
+  return error instanceof Error && normalizeState(error.message) === "pool rebalance is not started"
+}
+
 function deriveDecommissionStatus(info: JsonRecord): string {
   if (asBoolean(info.complete || info.Complete)) return "complete"
   if (asBoolean(info.failed || info.Failed)) return "failed"

--- a/tests/lib/pool-operations-safety.test.js
+++ b/tests/lib/pool-operations-safety.test.js
@@ -16,6 +16,20 @@ test("pool status reads fail closed instead of becoming idle or ready", () => {
   assert.match(decommission, /const \[dataReady, setDataReady\] = useState\(false\)/)
   assert.match(rebalance, /const interactionLocked =/)
   assert.match(decommission, /const interactionLocked =/)
+  assert.match(hook, /isRebalanceNotStartedError\(error\)/)
+  assert.match(hook, /normalizeRebalanceStatus\(\{ status: "idle" \}\)/)
+})
+
+test("decommission keeps pool data visible when only rebalance status fails", () => {
+  const source = read("app/(dashboard)/pool-decommission/page.tsx")
+
+  assert.match(source, /Promise\.allSettled\(/)
+  assert.match(source, /const \[rebalanceError, setRebalanceError\] = useState<string \| null>\(null\)/)
+  assert.match(source, /setRebalanceState\("unknown"\)/)
+  assert.match(source, /setDataReady\(true\)/)
+  assert.match(source, /Boolean\(rebalanceError\)/)
+  assert.match(source, /\{rebalanceError \? \(/)
+  assert.match(source, /t\("Unavailable"\)/)
 })
 
 test("pool operation requests reject stale responses and mutations use synchronous locks", () => {

--- a/tests/lib/pool-operations.test.js
+++ b/tests/lib/pool-operations.test.js
@@ -3,10 +3,18 @@ import assert from "node:assert/strict"
 import {
   deriveDecommissionDisplayState,
   deriveRebalanceDisplayState,
+  isRebalanceNotStartedError,
   normalizeDecommissionInfo,
   normalizePoolsOverview,
   normalizeRebalanceStatus,
 } from "../../lib/pool-operations.ts"
+
+test("isRebalanceNotStartedError recognizes only the expected idle response", () => {
+  assert.equal(isRebalanceNotStartedError(new Error("pool rebalance is not started")), true)
+  assert.equal(isRebalanceNotStartedError(new Error("  Pool Rebalance Is Not Started  ")), true)
+  assert.equal(isRebalanceNotStartedError(new Error("failed to read rebalance status")), false)
+  assert.equal(isRebalanceNotStartedError("pool rebalance is not started"), false)
+})
 
 test("normalizePoolsOverview computes support and capacities", () => {
   const overview = normalizePoolsOverview({


### PR DESCRIPTION
# Pull Request

## Description

Fix the pool decommission page so an expected `pool rebalance is not started` response is treated as an idle rebalance state instead of failing the entire page load.

The regression was introduced when pool operation reads were changed to fail closed. The rebalance status request was grouped with pool overview and decommission status requests, so the backend's expected not-started response prevented otherwise valid pool data from rendering.

This change:

- recognizes only the explicit rebalance-not-started error as idle
- keeps real rebalance status failures fail-closed
- preserves successfully loaded pool and decommission data when only rebalance status fails
- disables dependent actions and provides an in-context retry for partial failures
- ignores nested `.worktrees` build artifacts during repository linting

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed

```bash
pnpm install --frozen-lockfile
pnpm tsc --noEmit
pnpm lint
pnpm prettier --check .
pnpm test:run
```

All automated checks pass. The full test suite reports 312 passing tests.

Manual authenticated verification was not completed because the local browser session had expired.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

None.

## Screenshots (if applicable)

Not included because authenticated runtime verification was unavailable.

## Additional Notes

The `.worktrees/**` ESLint ignore prevents generated `.next` and `out` files from nested worktrees from breaking the repository's mandatory `pnpm lint` command.