### PR TITLE
fix(release): upload console package assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ on:
 env:
   NODE_VERSION: "22"
 
+permissions:
+  contents: write
+
 jobs:
   # ============================================================================
   # 预发布验证
@@ -125,6 +128,11 @@ jobs:
       - name: 📦 Create zip artifacts
         run: |
           set -euo pipefail
+          if [[ ! -s out/index.html ]]; then
+            echo "Console build is missing out/index.html" >&2
+            exit 1
+          fi
+
           mkdir -p artifacts
           (
             cd ./out
@@ -175,6 +183,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: 📥 Download release artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: release-build-${{ needs.pre-release-validation.outputs.version }}
+          path: release-assets
+
       - name: 📝 Generate changelog
         id: changelog
         run: |
@@ -197,6 +211,8 @@ jobs:
           body_path: CHANGELOG.md
           draft: false
           prerelease: ${{ contains(needs.pre-release-validation.outputs.version, '-') }}
+          files: release-assets/**/rustfs-console-${{ needs.pre-release-validation.outputs.version }}.zip
+          fail_on_unmatched_files: true
 
   # ============================================================================
   # 发布后通知


### PR DESCRIPTION
# Pull Request

## Description

Attach the verified console ZIP to each GitHub Release, and fail the release when the generated static bundle has no `index.html`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Security fix

## Testing

- [x] Manual package verification completed

```bash
pnpm lint
pnpm type-check
pnpm test:run
pnpm build
pnpm prettier --check .
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

N/A

## Screenshots (if applicable)

N/A

## Additional Notes

The release asset name is checked with `fail_on_unmatched_files`, so a release cannot succeed without an attachable console archive.
