### PR TITLE
fix(access-keys): load object policy responses

### DIFF
--- a/hooks/use-policies.ts
+++ b/hooks/use-policies.ts
@@ -2,6 +2,7 @@
 
 import { useCallback } from "react"
 import { useApi } from "@/contexts/api-context"
+import { normalizePolicyStatements } from "@/lib/user-policy"
 
 export function usePolicies() {
   const api = useApi()
@@ -81,33 +82,8 @@ export function usePolicies() {
       if (allPolicyNames.size > 0) {
         await Promise.all(
           Array.from(allPolicyNames).map(async (policyName) => {
-            const policyInfo = (await getPolicy(policyName)) as { policy?: string }
-            const policyDocument = JSON.parse(policyInfo.policy ?? "{}") as {
-              Statement?: Record<string, unknown>[]
-            }
-
-            if (!Array.isArray(policyDocument.Statement)) return
-
-            const groupOrigins = Object.entries(groupPoliciesMap)
-              .filter(([, policies]) => policies.includes(policyName))
-              .map(([groupName]) => groupName)
-
-            policyDocument.Statement.forEach((statement) => {
-              policyStatement.push({
-                ...statement,
-                Sid: statement.Sid ?? policyName,
-                Origin: {
-                  type:
-                    directPolicyNames.includes(policyName) && groupOrigins.length > 0
-                      ? "both"
-                      : directPolicyNames.includes(policyName)
-                        ? "direct"
-                        : "group",
-                  groups: groupOrigins,
-                  policyName,
-                },
-              })
-            })
+            const policyInfo = (await getPolicy(policyName)) as { policy?: unknown }
+            policyStatement.push(...normalizePolicyStatements(policyName, policyInfo.policy ?? {}))
           }),
         )
       }

--- a/lib/user-policy.ts
+++ b/lib/user-policy.ts
@@ -1,0 +1,27 @@
+type PolicyStatement = Record<string, unknown>
+
+export function normalizePolicyStatements(policyName: string, rawPolicy: unknown): PolicyStatement[] {
+  const policy = typeof rawPolicy === "string" ? (JSON.parse(rawPolicy) as unknown) : rawPolicy
+
+  if (typeof policy !== "object" || policy === null || Array.isArray(policy)) {
+    throw new TypeError("Policy must be a valid JSON object")
+  }
+
+  const statements = (policy as { Statement?: unknown }).Statement
+  if (statements === undefined) return []
+  if (!Array.isArray(statements)) {
+    throw new TypeError("Policy Statement must be an array")
+  }
+
+  return statements.map((statement) => {
+    if (typeof statement !== "object" || statement === null || Array.isArray(statement)) {
+      throw new TypeError("Policy Statement entries must be JSON objects")
+    }
+
+    const normalized = statement as PolicyStatement
+    return {
+      ...normalized,
+      Sid: normalized.Sid ?? policyName,
+    }
+  })
+}

--- a/tests/lib/user-policy.test.ts
+++ b/tests/lib/user-policy.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { normalizePolicyStatements } from "../../lib/user-policy"
+
+const policyStatement = {
+  Effect: "Allow",
+  Action: ["s3:GetObject"],
+  Resource: ["arn:aws:s3:::example/*"],
+}
+
+test("normalizePolicyStatements accepts policy objects returned by the admin API", () => {
+  assert.deepEqual(
+    normalizePolicyStatements("readonly", {
+      Version: "2012-10-17",
+      Statement: [policyStatement],
+    }),
+    [{ ...policyStatement, Sid: "readonly" }],
+  )
+})
+
+test("normalizePolicyStatements supports legacy string policy responses", () => {
+  assert.deepEqual(
+    normalizePolicyStatements(
+      "readonly",
+      JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{ ...policyStatement, Sid: "existing" }],
+      }),
+    ),
+    [{ ...policyStatement, Sid: "existing" }],
+  )
+})
+
+test("normalizePolicyStatements rejects invalid policy response shapes", () => {
+  assert.throws(() => normalizePolicyStatements("readonly", []), /valid JSON object/)
+  assert.throws(() => normalizePolicyStatements("readonly", { Statement: {} }), /Statement must be an array/)
+})


### PR DESCRIPTION
# Pull Request

## Description

Fix access key policy loading when the canned-policy endpoint returns a structured JSON object. The frontend now normalizes both object responses and legacy JSON strings, preserves statement identifiers, and no longer adds the UI-only `Origin` field to policy statements sent to the server.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed

```bash
pnpm install --frozen-lockfile --registry=https://registry.npmmirror.com
pnpm type-check
pnpm lint
pnpm test:run
pnpm format:check
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

Closes rustfs/rustfs#5017

## Screenshots (if applicable)

N/A — no visual changes.

## Additional Notes

The change is limited to access key policy response normalization and regression coverage.