### PR TITLE
fix: prevent duplicate running status requests

### DIFF
--- a/contexts/api-context.tsx
+++ b/contexts/api-context.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, useContext, useEffect, useState } from "react"
+import { createContext, useContext, useEffect, useRef, useState } from "react"
 import { usePathname, useRouter } from "next/navigation"
 import { ApiClient } from "@/lib/api-client"
 import { AwsClient } from "@/lib/aws4fetch"
@@ -22,6 +22,11 @@ export function ApiProvider({ children }: { children: React.ReactNode }) {
   const [isReady, setIsReady] = useState(false)
   const router = useRouter()
   const pathname = usePathname()
+  const pathnameRef = useRef(pathname)
+
+  useEffect(() => {
+    pathnameRef.current = pathname
+  }, [pathname])
 
   useEffect(() => {
     if (!isAuthenticated || !credentials?.AccessKeyId) {
@@ -65,7 +70,7 @@ export function ApiProvider({ children }: { children: React.ReactNode }) {
             return
           }
 
-          if (pathname === "/403/") return
+          if (pathnameRef.current === "/403/") return
           router.replace("/403/")
         },
       })
@@ -89,7 +94,6 @@ export function ApiProvider({ children }: { children: React.ReactNode }) {
     credentials?.SecretAccessKey,
     credentials?.SessionToken,
     logout,
-    pathname,
     router,
   ])
 

--- a/hooks/use-performance-data.ts
+++ b/hooks/use-performance-data.ts
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { useCallback, useEffect, useState } from "react"
 import { useSystem } from "@/hooks/use-system"
+import { scheduleMicrotask } from "@/lib/schedule-microtask"
 import {
   normalizeDataUsageInfo,
   normalizeMetricsInfo,
@@ -157,6 +158,7 @@ export function usePerformanceData() {
   }, [getDataUsageInfo, getStorageInfo, getSystemInfo, getSystemMetrics])
 
   useEffect(() => {
+    let cancelled = false
     mountedRef.current = true
     hasSystemDataRef.current = false
     setSystemInfo({})
@@ -169,7 +171,9 @@ export function usePerformanceData() {
     setSourceErrors({})
     setLastUpdatedAt(null)
     setMetricsUpdatedAt(null)
-    void refetch()
+    scheduleMicrotask(() => {
+      if (!cancelled) void refetch()
+    })
 
     const interval = window.setInterval(() => {
       if (document.visibilityState === "visible") void refetch()
@@ -181,6 +185,7 @@ export function usePerformanceData() {
     document.addEventListener("visibilitychange", handleVisibilityChange)
 
     return () => {
+      cancelled = true
       mountedRef.current = false
       requestVersionRef.current += 1
       abortControllerRef.current?.abort()

--- a/hooks/use-permissions.tsx
+++ b/hooks/use-permissions.tsx
@@ -5,6 +5,7 @@ import { hasConsoleScopes, type ConsolePolicy } from "@/lib/console-policy-parse
 import { hasConsoleCapability, type ConsoleCapability } from "@/lib/permission-capabilities"
 import type { PermissionResourceContext } from "@/lib/permission-resources"
 import { CONSOLE_SCOPES, PAGE_PERMISSIONS } from "@/lib/console-permissions"
+import { scheduleMicrotask } from "@/lib/schedule-microtask"
 import { useAuth } from "@/contexts/auth-context"
 import { useApiOptional } from "@/contexts/api-context"
 
@@ -130,8 +131,15 @@ export function PermissionsProvider({ children }: { children: React.ReactNode })
   )
 
   useEffect(() => {
+    let cancelled = false
     if (api && isAuthenticated && !hasResolvedAdmin) {
-      void fetchAdminStatus()
+      scheduleMicrotask(() => {
+        if (!cancelled) void fetchAdminStatus()
+      })
+    }
+
+    return () => {
+      cancelled = true
     }
   }, [api, isAuthenticated, hasResolvedAdmin, fetchAdminStatus])
 

--- a/tests/lib/login-performance-source.test.js
+++ b/tests/lib/login-performance-source.test.js
@@ -5,6 +5,7 @@ import fs from "node:fs"
 const rootLayout = fs.readFileSync("app/layout.tsx", "utf8")
 const dashboardLayout = fs.readFileSync("app/(dashboard)/layout.tsx", "utf8")
 const authContext = fs.readFileSync("contexts/auth-context.tsx", "utf8")
+const apiContext = fs.readFileSync("contexts/api-context.tsx", "utf8")
 const loginPage = fs.readFileSync("app/(auth)/auth/login/page.tsx", "utf8")
 const oidcCallbackPage = fs.readFileSync("app/(auth)/auth/oidc-callback/page.tsx", "utf8")
 const i18nProvider = fs.readFileSync("components/providers/i18n-provider.tsx", "utf8")
@@ -31,6 +32,17 @@ test("dashboard layout owns dashboard providers before the auth guard", () => {
   assert.ok(dashboardLayout.indexOf("<S3Provider>") < dashboardLayout.indexOf("<TaskProvider>"))
   assert.ok(dashboardLayout.indexOf("<TaskProvider>") < dashboardLayout.indexOf("<PermissionsProvider>"))
   assert.ok(dashboardLayout.indexOf("<PermissionsProvider>") < dashboardLayout.indexOf("<DashboardAuthGuard>"))
+})
+
+test("dashboard navigation does not recreate the API client", () => {
+  const apiSetupEffect = apiContext.match(
+    /useEffect\(\(\) => \{\n    if \(!isAuthenticated[\s\S]*?\n  \}, \[([\s\S]*?)\]\)/,
+  )
+
+  assert.ok(apiSetupEffect)
+  assert.doesNotMatch(apiSetupEffect[1], /pathname/)
+  assert.match(apiContext, /pathnameRef\.current = pathname/)
+  assert.match(apiContext, /pathnameRef\.current === "\/403\/"/)
 })
 
 test("auth routes do not depend on dashboard permission resolution", () => {

--- a/tests/lib/running-status-safety.test.js
+++ b/tests/lib/running-status-safety.test.js
@@ -4,6 +4,7 @@ import fs from "node:fs"
 
 const hookSource = fs.readFileSync("hooks/use-performance-data.ts", "utf8")
 const systemSource = fs.readFileSync("hooks/use-system.ts", "utf8")
+const permissionsSource = fs.readFileSync("hooks/use-permissions.tsx", "utf8")
 const pageSource = fs.readFileSync("app/(dashboard)/status/page.tsx", "utf8")
 const serverSource = fs.readFileSync("app/(dashboard)/_components/performance-server-list.tsx", "utf8")
 const usageSource = fs.readFileSync("app/(dashboard)/_components/performance-usage-card.tsx", "utf8")
@@ -24,6 +25,12 @@ test("performance refresh keeps partial data and rejects stale responses", () =>
   assert.match(hookSource, /hasSystemDataRef\.current = false[\s\S]*setSystemInfo\(\{\}\)/)
   assert.doesNotMatch(hookSource, /setLoading\(false\)[\s\S]*getSystemMetrics/)
   assert.ok((systemSource.match(/suppress403Redirect: true/g) ?? []).length >= 3)
+})
+
+test("running status skips Strict Mode preview requests", () => {
+  assert.match(hookSource, /scheduleMicrotask\(\(\) => \{\s*if \(!cancelled\) void refetch\(\)/)
+  assert.match(hookSource, /return \(\) => \{\s*cancelled = true/)
+  assert.match(permissionsSource, /scheduleMicrotask\(\(\) => \{\s*if \(!cancelled\) void fetchAdminStatus\(\)/)
 })
 
 test("running status distinguishes unknown values and exposes recovery feedback", () => {


### PR DESCRIPTION
# Pull Request

## Description

Prevent the Running Status page from issuing an initial request batch that is immediately canceled and repeated.

The duplicate traffic had two causes:
- route changes recreated the shared API client because the current pathname was part of its initialization effect dependencies;
- React Strict Mode's effect preview launched status and admin requests before the preview cleanup ran.

The API client now remains stable across dashboard navigation while the 403 handler reads the latest pathname through a ref. Initial status and admin requests are deferred to a cancelable microtask so Strict Mode preview effects do not reach the network.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed

```bash
pnpm install --frozen-lockfile
pnpm tsc --noEmit
pnpm lint
pnpm prettier --check .
pnpm test:run
git diff --check
```

All 338 tests pass.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

N/A

## Screenshots (if applicable)

N/A — request lifecycle behavior only; no visual changes.

## Additional Notes

The existing timeout, refresh interval, visibility refresh, request abort, and stale-response protection behavior remains unchanged.