### PR TITLE
fix(status): point listing troubleshooting link to public docs

### DIFF
--- a/app/(dashboard)/_components/performance-status-sources.tsx
+++ b/app/(dashboard)/_components/performance-status-sources.tsx
@@ -174,7 +174,7 @@ function PerformanceStatusSourcesContent({
       troubleshooting: t(
         "Correlate time-windowed walk_dir metrics and metacache logs before treating listing symptoms as a disk failure.",
       ),
-      troubleshootingHref: "https://github.com/rustfs/backlog/issues/1392#issuecomment-5040442761",
+      troubleshootingHref: "https://docs.rustfs.com/operations/monitoring",
     },
     { label: t("Workload Admission"), diagnostic: diagnostics.workloadAdmission },
   ]

--- a/tests/lib/running-status-safety.test.js
+++ b/tests/lib/running-status-safety.test.js
@@ -105,7 +105,7 @@ test("status sections expose semantic headings and named progress", () => {
   assert.match(statusSourcesSource, /Workload Admission/)
   assert.match(statusSourcesSource, /Not reported/)
   assert.match(statusSourcesSource, /Historical internode stall timeouts/)
-  assert.match(statusSourcesSource, /issuecomment-5040442761/)
+  assert.match(statusSourcesSource, /https:\/\/docs\.rustfs\.com\/operations\/monitoring/)
   assert.match(statusSourcesSource, /<Badge/)
   assert.match(statusSourcesSource, /<Separator/)
   assert.match(statusSourcesSource, /Correlate time-windowed walk_dir metrics and metacache logs/)


### PR DESCRIPTION
## Description

The **Running Status → Diagnostic Details** page renders a "Listing and Metacache" diagnostic whose troubleshooting link pointed to `https://github.com/rustfs/backlog/issues/1392#issuecomment-5040442761`. `rustfs/backlog` is an internal repository, so the link returns **404** for public users (reported in rustfs/rustfs#5199).

This repoints `troubleshootingHref` to the public monitoring guide at `https://docs.rustfs.com/operations/monitoring` (verified reachable, HTTP 200), which covers how RustFS exports metrics and how to verify them via the OpenTelemetry Collector → Prometheus → Grafana pipeline.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

`tests/lib/running-status-safety.test.js` pinned the old internal URL (`issuecomment-5040442761`); updated the assertion to match the new public docs URL.

```bash
pnpm type-check   # passes
pnpm lint         # passes
pnpm test:run     # the "status sections expose semantic headings" test passes with the updated assertion
```

Note: three pre-existing test failures (`dashboard navigation does not recreate the API client`, and two SSE narrow-screen tests) are present on a clean `main` checkout and are unrelated to this change.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] No new dependencies added

## Related Issues

Closes rustfs/rustfs#5199