### PR TITLE
fix(browser): handle object list access denied

### DIFF
--- a/app/(dashboard)/browser/content.tsx
+++ b/app/(dashboard)/browser/content.tsx
@@ -11,7 +11,6 @@ import { ObjectList } from "@/components/object/list"
 import { ObjectView } from "@/components/object/view"
 import { ObjectInfo } from "@/components/object/info"
 import { ObjectUploadPicker } from "@/components/object/upload-picker"
-import { useBucket } from "@/hooks/use-bucket"
 import { useMessage } from "@/lib/feedback/message"
 import { buildBucketPath } from "@/lib/bucket-path"
 import { useTasks } from "@/contexts/task-context"
@@ -32,7 +31,6 @@ export function BrowserContent({ bucketName, keyPath = "", preview = false, prev
   const searchParams = useSearchParams()
   const message = useMessage()
   const { canCapability } = usePermissions()
-  const { headBucket } = useBucket()
 
   const isObjectList = keyPath.endsWith("/") || keyPath === ""
   const prefix = keyPath.endsWith("/") ? keyPath : keyPath ? `${keyPath}/` : ""
@@ -45,30 +43,6 @@ export function BrowserContent({ bucketName, keyPath = "", preview = false, prev
   const [previewObject, setPreviewObject] = React.useState<Record<string, unknown> | null>(null)
   const objectApi = useObject(bucketName)
   const canUploadObjects = canCapability("objects.upload", { bucket: bucketName, prefix })
-
-  React.useEffect(() => {
-    if (!bucketName) return
-    headBucket(bucketName)
-      .then(() => {})
-      .catch((error: unknown) => {
-        const err = error as { $metadata?: { httpStatusCode?: number }; Code?: string; message?: string }
-        const status = err?.$metadata?.httpStatusCode
-        const code = (err?.Code ?? (error as Error)?.message ?? "").toLowerCase()
-        const isAccessDenied =
-          status === 403 ||
-          code === "accessdenied" ||
-          code === "forbidden" ||
-          (typeof code === "string" && (code.includes("access denied") || code.includes("forbidden")))
-        message.error(isAccessDenied ? t("Access Denied") : t("Bucket not found"))
-        const params = new URLSearchParams(searchParams.toString())
-        params.delete("bucket")
-        params.delete("prefix")
-        params.delete("preview")
-        params.delete("previewKey")
-        const query = params.toString()
-        router.push(query ? `/browser?${query}` : "/browser")
-      })
-  }, [bucketName, headBucket, message, router, t, searchParams])
 
   const bucketPath = React.useCallback((path?: string | string[]) => buildBucketPath(bucketName, path), [bucketName])
 

--- a/app/(dashboard)/sse/page.tsx
+++ b/app/(dashboard)/sse/page.tsx
@@ -545,9 +545,7 @@ export default function SSEPage() {
       if (values.backendType === "static") {
         if (!values.secretKey.trim()) {
           return {
-            error: t(
-              "Please enter the static KMS secret key (base64-encoded 32-byte AES-256 key).",
-            ),
+            error: t("Please enter the static KMS secret key (base64-encoded 32-byte AES-256 key)."),
             field: "secretKey",
           }
         }
@@ -1548,7 +1546,13 @@ export default function SSEPage() {
                     <Button
                       size="sm"
                       onClick={() => setCreateKeyOpen(true)}
-                      disabled={Boolean(activeMutation) || loadingKeys || loadingStatus || Boolean(keysError) || staticKmsReadOnly}
+                      disabled={
+                        Boolean(activeMutation) ||
+                        loadingKeys ||
+                        loadingStatus ||
+                        Boolean(keysError) ||
+                        staticKmsReadOnly
+                      }
                     >
                       <RiAddLine className="size-4" aria-hidden />
                       {t("Create Key")}
@@ -1642,7 +1646,11 @@ export default function SSEPage() {
                                   variant="outline"
                                   className="min-h-11 flex-1 sm:flex-none"
                                   disabled={
-                                    isDefaultKey || Boolean(activeMutation) || loadingStatus || Boolean(keysError) || staticKmsReadOnly
+                                    isDefaultKey ||
+                                    Boolean(activeMutation) ||
+                                    loadingStatus ||
+                                    Boolean(keysError) ||
+                                    staticKmsReadOnly
                                   }
                                   onClick={() => setPendingKeyAction({ type: "scheduleDelete", key })}
                                 >
@@ -1654,7 +1662,11 @@ export default function SSEPage() {
                                 variant="destructive"
                                 className="min-h-11 flex-1 sm:flex-none"
                                 disabled={
-                                  isDefaultKey || Boolean(activeMutation) || loadingStatus || Boolean(keysError) || staticKmsReadOnly
+                                  isDefaultKey ||
+                                  Boolean(activeMutation) ||
+                                  loadingStatus ||
+                                  Boolean(keysError) ||
+                                  staticKmsReadOnly
                                 }
                                 onClick={() => setPendingKeyAction({ type: "forceDelete", key })}
                               >

--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -14,6 +14,7 @@ interface DataTableProps<TData> {
   isLoading?: boolean
   emptyTitle?: string
   emptyDescription?: string
+  emptyAction?: React.ReactNode
   caption?: string
   className?: string
   tableClass?: string
@@ -69,6 +70,7 @@ export function DataTable<TData>({
   isLoading = false,
   emptyTitle = "No data",
   emptyDescription = "There is nothing to display yet.",
+  emptyAction,
   caption,
   className,
   tableClass,
@@ -153,7 +155,9 @@ export function DataTable<TData>({
         ) : (
           <TableRow>
             <TableCell colSpan={visibleColumnCount} className="h-48">
-              <EmptyState title={emptyTitle} description={emptyDescription} />
+              <EmptyState title={emptyTitle} description={emptyDescription}>
+                {emptyAction}
+              </EmptyState>
             </TableCell>
           </TableRow>
         )}

--- a/components/object/list.tsx
+++ b/components/object/list.tsx
@@ -47,6 +47,7 @@ import { useLocalStorage } from "@/hooks/use-local-storage"
 import { usePermissions } from "@/hooks/use-permissions"
 import { useApi } from "@/contexts/api-context"
 import { useMessage } from "@/lib/feedback/message"
+import { isAccessDeniedError } from "@/lib/error-handler"
 import { exportFile } from "@/lib/export-file"
 import { getContentType } from "@/lib/mime-types"
 import { formatBytes, formatDateTime } from "@/lib/functions"
@@ -57,6 +58,7 @@ import {
   resolveObjectListDisplayState,
   shouldApplyObjectListResponse,
   shouldResetObjectListPagination,
+  type ObjectListErrorState,
 } from "@/lib/object-list-state"
 import { OBJECT_LIST_DEFAULT_PAGE_SIZE, resolveObjectListPageSize } from "@/lib/object-list-pagination"
 import {
@@ -115,7 +117,7 @@ export function ObjectList({
   const api = useApi()
   const { listObject, getSignedUrl, renameObject } = useObject(bucket)
   const { getBucketVersioning } = useBucket()
-  const { canCapability } = usePermissions()
+  const { canCapability, hasPermission } = usePermissions()
   const addDeleteKeys = useAddDeleteKeys()
   const addDeleteFolder = useAddDeleteFolder()
   const tasks = useTasks()
@@ -129,6 +131,7 @@ export function ObjectList({
   const [bucketVersioningState, setBucketVersioningState] = React.useState<BucketVersioningState>("unknown")
   const [versioningError, setVersioningError] = React.useState("")
   const [versioningReload, setVersioningReload] = React.useState(0)
+  const [listError, setListError] = React.useState<ObjectListErrorState>(null)
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
   const [deleteDialogKeys, setDeleteDialogKeys] = React.useState<string[]>([])
   const [deleteAllVersions, setDeleteAllVersions] = React.useState(false)
@@ -151,6 +154,7 @@ export function ObjectList({
   )
   const canBulkDelete = canCapability("objects.bulkDelete", { bucket, prefix })
   const canBulkDownload = canCapability("objects.download", { bucket, prefix })
+  const shouldLoadBucketVersioning = hasPermission("s3:DeleteObject")
 
   const bucketPath = React.useCallback((p?: string | string[]) => buildBucketPath(bucket, p), [bucket])
   const requestIdRef = React.useRef(0)
@@ -203,6 +207,9 @@ export function ObjectList({
       const requestScope = activeScopeRef.current
       loadingRef.current = true
       setLoading(true)
+      if (!shouldAppend) {
+        setListError(null)
+      }
       try {
         const response = await listObject(bucket, prefix || undefined, resolvedPageSize, token, {
           includeDeleted: showDeleted,
@@ -249,7 +256,6 @@ export function ObjectList({
         }
       } catch (error) {
         console.error("Failed to fetch objects:", error)
-        message.error((error as Error)?.message ?? t("Failed to load objects"))
         if (
           shouldApplyObjectListResponse({
             requestId,
@@ -258,9 +264,15 @@ export function ObjectList({
             activeScope: activeScopeRef.current,
           })
         ) {
+          const accessDenied = isAccessDeniedError(error)
+          message.error(accessDenied ? t("Access Denied") : ((error as Error)?.message ?? t("Failed to load objects")))
           setNextToken(undefined)
-          if (!shouldAppend) {
+          if (accessDenied) {
             setData([])
+            setListError("access-denied")
+          } else if (!shouldAppend) {
+            setData([])
+            setListError("error")
           }
         }
       } finally {
@@ -323,6 +335,12 @@ export function ObjectList({
   }, [tasks, resetAndFetchObjects])
 
   React.useEffect(() => {
+    if (!shouldLoadBucketVersioning) {
+      setBucketVersioningState("unknown")
+      setVersioningError("")
+      return
+    }
+
     let cancelled = false
 
     const loadBucketVersioningStatus = async () => {
@@ -337,8 +355,13 @@ export function ObjectList({
       } catch (error) {
         console.error("Failed to load bucket versioning status:", error)
         if (!cancelled) {
-          setBucketVersioningState("unknown")
-          setVersioningError(t("Failed to get data"))
+          if (isAccessDeniedError(error)) {
+            setBucketVersioningState("unknown")
+            setVersioningError(t("Unable to load versioning status."))
+          } else {
+            setBucketVersioningState("unknown")
+            setVersioningError(t("Failed to get data"))
+          }
         }
       }
     }
@@ -348,7 +371,7 @@ export function ObjectList({
     return () => {
       cancelled = true
     }
-  }, [bucket, getBucketVersioning, t, versioningReload])
+  }, [bucket, getBucketVersioning, shouldLoadBucketVersioning, t, versioningReload])
 
   const displayKey = React.useCallback(
     (key: string) => {
@@ -374,18 +397,29 @@ export function ObjectList({
     loadedCount: data.length,
     hasMore: Boolean(nextToken),
     loading,
+    error: listError,
   })
   const filteredEmptyState = displayState === "filtered-partial" || displayState === "filtered-empty"
-  const emptyTitle = filteredEmptyState
-    ? t(displayState === "filtered-partial" ? "No matches in loaded objects" : "No matching objects")
-    : t("No Objects")
-  const emptyDescription = filteredEmptyState
-    ? t(
-        displayState === "filtered-partial"
-          ? "More objects have not been searched yet."
-          : "No loaded objects match this filter.",
-      )
-    : t("Upload files or create folders to populate this bucket.")
+  const emptyTitle =
+    displayState === "access-denied"
+      ? t("Access Denied")
+      : displayState === "error"
+        ? t("Failed to load objects")
+        : filteredEmptyState
+          ? t(displayState === "filtered-partial" ? "No matches in loaded objects" : "No matching objects")
+          : t("No Objects")
+  const emptyDescription =
+    displayState === "access-denied"
+      ? t("Ask your administrator to grant permission to list objects in this bucket.")
+      : displayState === "error"
+        ? t("Refresh to try again.")
+        : filteredEmptyState
+          ? t(
+              displayState === "filtered-partial"
+                ? "More objects have not been searched yet."
+                : "No loaded objects match this filter.",
+            )
+          : t("Upload files or create folders to populate this bucket.")
 
   const downloadFile = React.useCallback(
     async (key: string) => {
@@ -824,7 +858,7 @@ export function ObjectList({
         </div>
       </PageHeader>
 
-      {bucketVersioningState === "unknown" ? (
+      {shouldLoadBucketVersioning && !listError && bucketVersioningState === "unknown" ? (
         <div
           id="object-versioning-status"
           role={versioningError ? "alert" : "status"}
@@ -852,16 +886,26 @@ export function ObjectList({
         isLoading={displayState === "loading" || displayState === "filtered-loading"}
         emptyTitle={emptyTitle}
         emptyDescription={emptyDescription}
+        emptyAction={
+          displayState === "error" ? (
+            <Button type="button" variant="outline" onClick={resetAndFetchObjects}>
+              <RiRefreshLine className="size-4" aria-hidden />
+              {t("Refresh")}
+            </Button>
+          ) : undefined
+        }
       />
 
-      <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
-        <span>
-          {t("Loaded {count} objects", {
-            count: data.length,
-          })}
-        </span>
-        <span>{t("Filtering and sorting apply to loaded objects")}</span>
-      </div>
+      {!listError ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
+          <span>
+            {t("Loaded {count} objects", {
+              count: data.length,
+            })}
+          </span>
+          <span>{t("Filtering and sorting apply to loaded objects")}</span>
+        </div>
+      ) : null}
 
       {nextToken ? (
         <div ref={loadMoreRef} className="flex min-h-10 items-center justify-center text-sm text-muted-foreground">

--- a/i18n/locales/ar-MA.json
+++ b/i18n/locales/ar-MA.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "التحكم في الوصول",
   "Access Denied": "تم رفض الوصول",
+  "Ask your administrator to grant permission to list objects in this bucket.": "اطلب من المسؤول منحك إذن عرض الكائنات في هذه الحاوية.",
   "Access Key": "مفتاح الوصول",
   "Access Key *": "مفتاح الوصول *",
   "Access Key is required": "مفتاح الوصول مطلوب",

--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "Zugriffskontrolle",
   "Access Denied": "Zugriff verweigert",
+  "Ask your administrator to grant permission to list objects in this bucket.": "Bitten Sie Ihren Administrator, die Berechtigung zum Auflisten der Objekte in diesem Bucket zu erteilen.",
   "Access Key": "Zugriffsschlüssel",
   "Access Key *": "Zugriffsschlüssel *",
   "Access Key is required": "Zugriffsschlüssel ist erforderlich",

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "Access Control",
   "Access Denied": "Access Denied",
+  "Ask your administrator to grant permission to list objects in this bucket.": "Ask your administrator to grant permission to list objects in this bucket.",
   "Access Key": "Access Key",
   "Access Key *": "Access Key *",
   "Access Key is required": "Access Key is required",

--- a/i18n/locales/es-ES.json
+++ b/i18n/locales/es-ES.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "Control de Acceso",
   "Access Denied": "Acceso Denegado",
+  "Ask your administrator to grant permission to list objects in this bucket.": "Pida a su administrador que conceda permiso para enumerar los objetos de este bucket.",
   "Access Key": "Clave de Acceso",
   "Access Key *": "Clave de Acceso *",
   "Access Key is required": "La clave de acceso es obligatoria",

--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "Contrôle d'accès",
   "Access Denied": "Accès Refusé",
+  "Ask your administrator to grant permission to list objects in this bucket.": "Demandez à votre administrateur d’accorder l’autorisation de répertorier les objets de ce bucket.",
   "Access Key": "Clé d'accès",
   "Access Key *": "Clé d'accès *",
   "Access Key is required": "La clé d'accès est requise",

--- a/i18n/locales/id-ID.json
+++ b/i18n/locales/id-ID.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "Kontrol Akses",
   "Access Denied": "Akses Ditolak",
+  "Ask your administrator to grant permission to list objects in this bucket.": "Minta administrator Anda memberikan izin untuk mencantumkan objek dalam bucket ini.",
   "Access Key": "Access Key",
   "Access Key *": "Access Key *",
   "Access Key is required": "Access Key wajib diisi",

--- a/i18n/locales/it-IT.json
+++ b/i18n/locales/it-IT.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "Controllo accessi",
   "Access Denied": "Accesso Negato",
+  "Ask your administrator to grant permission to list objects in this bucket.": "Chiedi all’amministratore di concedere l’autorizzazione per elencare gli oggetti in questo bucket.",
   "Access Key": "Chiave di accesso",
   "Access Key *": "Chiave di accesso *",
   "Access Key is required": "La chiave di accesso è obbligatoria",

--- a/i18n/locales/ja-JP.json
+++ b/i18n/locales/ja-JP.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "アクセス制御",
   "Access Denied": "アクセス拒否",
+  "Ask your administrator to grant permission to list objects in this bucket.": "このバケット内のオブジェクトを一覧表示する権限を管理者に付与してもらってください。",
   "Access Key": "アクセスキー",
   "Access Key *": "アクセスキー *",
   "Access Key is required": "アクセスキーは必須です",

--- a/i18n/locales/ko-KR.json
+++ b/i18n/locales/ko-KR.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "액세스 제어",
   "Access Denied": "액세스 거부",
+  "Ask your administrator to grant permission to list objects in this bucket.": "관리자에게 이 버킷의 객체를 나열할 수 있는 권한을 요청하세요.",
   "Access Key": "액세스 키",
   "Access Key *": "액세스 키 *",
   "Access Key is required": "액세스 키가 필요합니다",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "Controle de Acesso",
   "Access Denied": "Acesso Negado",
+  "Ask your administrator to grant permission to list objects in this bucket.": "Peça ao administrador para conceder permissão para listar os objetos deste bucket.",
   "Access Key": "Chave de Acesso",
   "Access Key *": "Chave de Acesso *",
   "Access Key is required": "Chave de acesso é obrigatória",

--- a/i18n/locales/ru-RU.json
+++ b/i18n/locales/ru-RU.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "Контроль доступа",
   "Access Denied": "Доступ запрещен",
+  "Ask your administrator to grant permission to list objects in this bucket.": "Попросите администратора предоставить разрешение на просмотр списка объектов в этом бакете.",
   "Access Key": "Ключ доступа",
   "Access Key *": "Ключ доступа *",
   "Access Key is required": "Ключ доступа обязателен",

--- a/i18n/locales/tr-TR.json
+++ b/i18n/locales/tr-TR.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "Erişim Kontrolü",
   "Access Denied": "Erişim Reddedildi",
+  "Ask your administrator to grant permission to list objects in this bucket.": "Yöneticinizden bu bucket içindeki nesneleri listeleme izni vermesini isteyin.",
   "Access Key": "Erişim Anahtarı",
   "Access Key *": "Erişim Anahtarı *",
   "Access Key is required": "Erişim Anahtarı gerekli",

--- a/i18n/locales/vi-VN.json
+++ b/i18n/locales/vi-VN.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "Kiểm soát truy cập",
   "Access Denied": "Truy cập bị từ chối",
+  "Ask your administrator to grant permission to list objects in this bucket.": "Hãy yêu cầu quản trị viên cấp quyền liệt kê các đối tượng trong bucket này.",
   "Access Key": "Khóa truy cập",
   "Access Key *": "Khóa truy cập *",
   "Access Key is required": "Yêu cầu nhập Khóa truy cập",

--- a/i18n/locales/zh-CN.json
+++ b/i18n/locales/zh-CN.json
@@ -22,6 +22,7 @@
   "AWS S3": "AWS S3",
   "Access Control": "访问控制",
   "Access Denied": "无权限访问",
+  "Ask your administrator to grant permission to list objects in this bucket.": "请联系管理员授予列出此存储桶中对象的权限。",
   "Access Key": "访问密钥",
   "Access Key *": "访问密钥 *",
   "Access Key is required": "访问密钥为必填项",

--- a/lib/error-handler.ts
+++ b/lib/error-handler.ts
@@ -155,6 +155,30 @@ export const getServiceErrorMessage = (error: unknown): string | null => {
   return codeCandidates.find(Boolean) ?? messageCandidates.find(Boolean) ?? null
 }
 
+export const isAccessDeniedError = (error: unknown): boolean => {
+  if (!error || typeof error !== "object") {
+    return false
+  }
+
+  const candidate = error as {
+    name?: unknown
+    code?: unknown
+    Code?: unknown
+    Error?: { Code?: unknown }
+    status?: unknown
+    statusCode?: unknown
+    $metadata?: { httpStatusCode?: unknown }
+  }
+  const statuses = [candidate.status, candidate.statusCode, candidate.$metadata?.httpStatusCode]
+  if (statuses.some((status) => status === 403)) {
+    return true
+  }
+
+  const accessDeniedCodes = new Set(["accessdenied", "forbidden"])
+  const codes = [candidate.name, candidate.code, candidate.Code, candidate.Error?.Code]
+  return codes.some((code) => typeof code === "string" && accessDeniedCodes.has(code.toLowerCase()))
+}
+
 export class ConfigLoadError extends Error {
   code: "INVALID_URL" | "STORAGE_ERROR" | "NETWORK_ERROR" | "UNKNOWN_ERROR"
   originalError?: Error

--- a/lib/object-list-state.ts
+++ b/lib/object-list-state.ts
@@ -13,6 +13,8 @@ interface ObjectListResponseGuardParams {
 }
 
 export type ObjectListDisplayState =
+  | "access-denied"
+  | "error"
   | "loading"
   | "empty"
   | "filtered-loading"
@@ -20,12 +22,15 @@ export type ObjectListDisplayState =
   | "filtered-empty"
   | "content"
 
+export type ObjectListErrorState = Extract<ObjectListDisplayState, "access-denied" | "error"> | null
+
 interface ObjectListDisplayStateParams {
   searchTerm: string
   filteredCount: number
   loadedCount: number
   hasMore: boolean
   loading: boolean
+  error: ObjectListErrorState
 }
 
 export function createObjectListScope(scope: ObjectListScope): ObjectListScope {
@@ -60,7 +65,9 @@ export function resolveObjectListDisplayState({
   loadedCount,
   hasMore,
   loading,
+  error,
 }: ObjectListDisplayStateParams): ObjectListDisplayState {
+  if (error) return error
   if (filteredCount > 0) return "content"
 
   const isFiltering = searchTerm.trim().length > 0

--- a/tests/lib/error-handler.test.ts
+++ b/tests/lib/error-handler.test.ts
@@ -53,3 +53,12 @@ test("getXmlErrorMessage prefers detailed XML messages over generic error codes"
     "Object is under COMPLIANCE retention and cannot be deleted until 2026-05-13T00:00:00Z",
   )
 })
+
+test("isAccessDeniedError recognizes S3 access denied responses", async () => {
+  const { isAccessDeniedError } = await loadErrorHandler()
+
+  assert.equal(isAccessDeniedError({ name: "AccessDenied" }), true)
+  assert.equal(isAccessDeniedError({ Code: "Forbidden" }), true)
+  assert.equal(isAccessDeniedError({ $metadata: { httpStatusCode: 403 } }), true)
+  assert.equal(isAccessDeniedError({ name: "NoSuchBucket", $metadata: { httpStatusCode: 404 } }), false)
+})

--- a/tests/lib/object-delete-safety.test.js
+++ b/tests/lib/object-delete-safety.test.js
@@ -19,7 +19,16 @@ test("unknown bucket versioning state never enables force delete", () => {
 test("object deletion stays blocked until versioning state is known", () => {
   assert.match(objectListSource, /setBucketVersioningState\("unknown"\)/)
   assert.match(objectListSource, /versioningError/)
+  assert.match(
+    objectListSource,
+    /if \(isAccessDeniedError\(error\)\) \{\s+setBucketVersioningState\("unknown"\)\s+setVersioningError\(t\("Unable to load versioning status\."\)\)/,
+  )
+  assert.match(objectListSource, /const shouldLoadBucketVersioning = hasPermission\("s3:DeleteObject"\)/)
+  assert.match(objectListSource, /if \(!shouldLoadBucketVersioning\) \{[\s\S]{0,160}return/)
   assert.match(objectListSource, /bucketVersioningState === "unknown"/)
   assert.match(objectListSource, /role=\{versioningError \? "alert" : "status"\}/)
-  assert.doesNotMatch(objectListSource, /catch\s*\{[\s\S]{0,120}setBucketVersioningState\("disabled"\)/)
+  assert.doesNotMatch(
+    objectListSource,
+    /if \(isAccessDeniedError\(error\)\) \{[\s\S]{0,160}setBucketVersioningState\("disabled"\)/,
+  )
 })

--- a/tests/lib/object-list-source.test.js
+++ b/tests/lib/object-list-source.test.js
@@ -14,8 +14,37 @@ test("object list falls back to an empty table instead of crashing the page on f
   const source = fs.readFileSync("components/object/list.tsx", "utf8")
 
   assert.equal(source.includes('console.error("Failed to fetch objects:", error)'), true)
-  assert.equal(source.includes('message.error((error as Error)?.message ?? t("Failed to load objects"))'), true)
+  assert.equal(source.includes('message.error(accessDenied ? t("Access Denied")'), true)
+  assert.equal(source.includes('t("Failed to load objects")'), true)
   assert.equal(source.includes("setData([])"), true)
+})
+
+test("object browser keeps the bucket open and explains missing list permission", () => {
+  const browserSource = fs.readFileSync("app/(dashboard)/browser/content.tsx", "utf8")
+  const listSource = fs.readFileSync("components/object/list.tsx", "utf8")
+
+  assert.equal(browserSource.includes("headBucket(bucketName)"), false)
+  assert.equal(
+    listSource.includes("const [listError, setListError] = React.useState<ObjectListErrorState>(null)"),
+    true,
+  )
+  assert.match(
+    listSource,
+    /if \(accessDenied\) \{\s+setData\(\[\]\)\s+setListError\("access-denied"\)\s+\} else if \(!shouldAppend\)/,
+  )
+  assert.equal(
+    listSource.includes('t("Ask your administrator to grant permission to list objects in this bucket.")'),
+    true,
+  )
+})
+
+test("object list keeps read failures distinct from an empty bucket and offers retry", () => {
+  const source = fs.readFileSync("components/object/list.tsx", "utf8")
+
+  assert.equal(source.includes('setListError("error")'), true)
+  assert.equal(source.includes('displayState === "error"'), true)
+  assert.equal(source.includes("emptyAction={"), true)
+  assert.equal(source.includes("onClick={resetAndFetchObjects}"), true)
 })
 
 test("object list lazy loads additional object batches instead of showing a paginator", () => {

--- a/tests/lib/object-list-state.test.ts
+++ b/tests/lib/object-list-state.test.ts
@@ -129,6 +129,7 @@ test("resolveObjectListDisplayState treats an unfiltered empty response as an em
       loadedCount: 0,
       hasMore: false,
       loading: false,
+      error: null,
     }),
     "empty",
   )
@@ -142,6 +143,7 @@ test("resolveObjectListDisplayState keeps a filtered append request in loading s
       loadedCount: 25,
       hasMore: true,
       loading: true,
+      error: null,
     }),
     "filtered-loading",
   )
@@ -155,6 +157,7 @@ test("resolveObjectListDisplayState reports when unsearched objects remain", () 
       loadedCount: 25,
       hasMore: true,
       loading: false,
+      error: null,
     }),
     "filtered-partial",
   )
@@ -168,6 +171,7 @@ test("resolveObjectListDisplayState reports a final filtered-empty state after a
       loadedCount: 50,
       hasMore: false,
       loading: false,
+      error: null,
     }),
     "filtered-empty",
   )
@@ -181,6 +185,7 @@ test("resolveObjectListDisplayState shows matching rows while more objects load"
       loadedCount: 25,
       hasMore: true,
       loading: true,
+      error: null,
     }),
     "content",
   )
@@ -194,7 +199,36 @@ test("resolveObjectListDisplayState ignores whitespace around the filter term", 
       loadedCount: 0,
       hasMore: false,
       loading: false,
+      error: null,
     }),
     "empty",
+  )
+})
+
+test("resolveObjectListDisplayState prioritizes access denied over previously loaded rows", () => {
+  assert.equal(
+    resolveObjectListDisplayState({
+      searchTerm: "",
+      filteredCount: 25,
+      loadedCount: 25,
+      hasMore: false,
+      loading: false,
+      error: "access-denied",
+    }),
+    "access-denied",
+  )
+})
+
+test("resolveObjectListDisplayState keeps read failures distinct from an empty bucket", () => {
+  assert.equal(
+    resolveObjectListDisplayState({
+      searchTerm: "",
+      filteredCount: 0,
+      loadedCount: 0,
+      hasMore: false,
+      loading: false,
+      error: "error",
+    }),
+    "error",
   )
 })

--- a/tests/lib/sse-safety.test.js
+++ b/tests/lib/sse-safety.test.js
@@ -18,7 +18,7 @@ test("SSE status and key reads fail closed with persistent recovery states", () 
   assert.match(source, /statusError \|\| keysError \|\| loadingKeys \|\| loadingStatus/)
   assert.match(
     source,
-    /disabled=\{Boolean\(activeMutation\) \|\| loadingKeys \|\| loadingStatus \|\| Boolean\(keysError\)/,
+    /disabled=\{\s*Boolean\(activeMutation\)\s*\|\|\s*loadingKeys\s*\|\|\s*loadingStatus\s*\|\|\s*Boolean\(keysError\)/,
   )
 })
 


### PR DESCRIPTION
# Pull Request

## Description

Keep the object browser on the selected bucket when object listing is denied, matching MinIO Console behavior.

The previous `HeadBucket` preflight redirected on `403` before the authoritative `ListObjectsV2` request could determine whether the bucket contents were readable. This change:

- relies on `ListObjectsV2` as the source of truth for object-list access;
- renders persistent access-denied and load-failed states instead of presenting failures as an empty bucket;
- clears stale rows when a paginated list request is denied;
- provides an in-context retry action for ordinary list failures;
- loads bucket versioning only for sessions that can delete objects and keeps deletion fail-closed when the versioning state cannot be read;
- adds localized permission guidance and regression coverage.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

```bash
pnpm install --frozen-lockfile
pnpm type-check
pnpm lint
pnpm test:run
pnpm exec prettier --check .
git diff --check
```

All 372 tests pass. The local Console login flow was also smoke-tested in the browser with no framework errors.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

Closes #185

## Screenshots (if applicable)

Not included because reproducing the permission-denied state requires dedicated read-only credentials.

## Additional Notes

The latest `main` branch contained four Prettier-only differences in the SSE page. They are formatted here together with a whitespace-tolerant update to the associated source assertion so the required repository-wide format check passes.

Validation ran with Node.js 24.14 because Node.js 22 was not available through `nvm` in the local environment.
