### PR TITLE
fix: handle readonly bucket states safely

### DIFF
--- a/app/(dashboard)/browser/content.tsx
+++ b/app/(dashboard)/browser/content.tsx
@@ -18,6 +18,7 @@ import { useTasks } from "@/contexts/task-context"
 import { ObjectPreviewModal } from "@/components/object/preview-modal"
 import { useObject } from "@/hooks/use-object"
 import { usePermissions } from "@/hooks/use-permissions"
+import { isMissingBucketError } from "@/lib/bucket-access"
 
 interface BrowserContentProps {
   bucketName: string
@@ -51,15 +52,9 @@ export function BrowserContent({ bucketName, keyPath = "", preview = false, prev
     headBucket(bucketName)
       .then(() => {})
       .catch((error: unknown) => {
-        const err = error as { $metadata?: { httpStatusCode?: number }; Code?: string; message?: string }
-        const status = err?.$metadata?.httpStatusCode
-        const code = (err?.Code ?? (error as Error)?.message ?? "").toLowerCase()
-        const isAccessDenied =
-          status === 403 ||
-          code === "accessdenied" ||
-          code === "forbidden" ||
-          (typeof code === "string" && (code.includes("access denied") || code.includes("forbidden")))
-        message.error(isAccessDenied ? t("Access Denied") : t("Bucket not found"))
+        if (!isMissingBucketError(error)) return
+
+        message.error(t("Bucket not found"))
         const params = new URLSearchParams(searchParams.toString())
         params.delete("bucket")
         params.delete("prefix")

--- a/app/(dashboard)/browser/page.tsx
+++ b/app/(dashboard)/browser/page.tsx
@@ -21,6 +21,7 @@ import { useMessage } from "@/lib/feedback/message"
 import { formatDateTime, formatInteger, niceBytes } from "@/lib/functions"
 import { normalizeDateToIso } from "@/lib/safe-date"
 import { getAccountBucketUsage } from "@/lib/account-bucket-usage"
+import { loadBucketPolicyStatuses } from "@/lib/bucket-policy-status"
 import { BrowserContent } from "./content"
 import type { ColumnDef } from "@tanstack/react-table"
 
@@ -58,26 +59,13 @@ function BrowserBucketsPage() {
       }
 
       try {
-        const results = await Promise.all(
-          bucketNames.map(async (name) => {
-            try {
-              const resp = (await getBucketPolicyStatus(name)) as {
-                PolicyStatus?: { IsPublic?: boolean }
-              }
-              return { name, isPublic: resp?.PolicyStatus?.IsPublic === true }
-            } catch {
-              return { name, isPublic: false }
-            }
-          }),
-        )
+        const policyMap = await loadBucketPolicyStatuses(bucketNames, getBucketPolicyStatus)
         if (fetchId !== fetchIdRef.current) return
-
-        const policyMap = Object.fromEntries(results.map((r) => [r.name, r.isPublic]))
 
         setData((prev) =>
           prev.map((row) => ({
             ...row,
-            IsPublic: policyMap[row.Name] ?? false,
+            IsPublic: policyMap[row.Name],
           })),
         )
       } catch {
@@ -226,7 +214,7 @@ function BrowserBucketsPage() {
           <span className="text-muted-foreground">{t("Private")}</span>
         )
       }
-      return policyLoading ? <Spinner className="size-3 text-muted-foreground" /> : "--"
+      return policyLoading ? <Spinner className="size-3 text-muted-foreground" /> : "-"
     },
   })
 

--- a/components/buckets/list.tsx
+++ b/components/buckets/list.tsx
@@ -14,6 +14,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { formatDateTime, formatInteger, niceBytes } from "@/lib/functions"
 import { normalizeDateToIso } from "@/lib/safe-date"
 import { getAccountBucketUsage } from "@/lib/account-bucket-usage"
+import { loadBucketPolicyStatuses } from "@/lib/bucket-policy-status"
 import type { ColumnDef } from "@tanstack/react-table"
 
 export interface BucketListRow {
@@ -50,25 +51,13 @@ export function BucketList({ title, emptyDescription, getBucketHref }: BucketLis
       }
 
       try {
-        const results = await Promise.all(
-          bucketNames.map(async (name) => {
-            try {
-              const resp = (await getBucketPolicyStatus(name)) as {
-                PolicyStatus?: { IsPublic?: boolean }
-              }
-              return { name, isPublic: resp?.PolicyStatus?.IsPublic === true }
-            } catch {
-              return { name, isPublic: false }
-            }
-          }),
-        )
+        const policyMap = await loadBucketPolicyStatuses(bucketNames, getBucketPolicyStatus)
         if (fetchId !== fetchIdRef.current) return
 
-        const policyMap = Object.fromEntries(results.map((r) => [r.name, r.isPublic]))
         setData((prev) =>
           prev.map((row) => ({
             ...row,
-            IsPublic: policyMap[row.Name] ?? false,
+            IsPublic: policyMap[row.Name],
           })),
         )
       } finally {
@@ -202,7 +191,7 @@ export function BucketList({ title, emptyDescription, getBucketHref }: BucketLis
               <span className="text-muted-foreground">{t("Private")}</span>
             )
           }
-          return policyLoading ? <Spinner className="size-3 text-muted-foreground" /> : "--"
+          return policyLoading ? <Spinner className="size-3 text-muted-foreground" /> : "-"
         },
       },
     ],

--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -12,6 +12,8 @@ import { cn } from "@/lib/utils"
 interface DataTableProps<TData> {
   table: Table<TData>
   isLoading?: boolean
+  errorTitle?: string
+  errorDescription?: string
   emptyTitle?: string
   emptyDescription?: string
   caption?: string
@@ -67,6 +69,8 @@ function getAriaSort<TData>(column: Column<TData, unknown>): React.AriaAttribute
 export function DataTable<TData>({
   table,
   isLoading = false,
+  errorTitle,
+  errorDescription,
   emptyTitle = "No data",
   emptyDescription = "There is nothing to display yet.",
   caption,
@@ -129,6 +133,14 @@ export function DataTable<TData>({
               <div className="flex flex-col items-center gap-2">
                 <Spinner className="size-6" />
                 <span className="text-sm text-muted-foreground">Loading…</span>
+              </div>
+            </TableCell>
+          </TableRow>
+        ) : errorTitle ? (
+          <TableRow>
+            <TableCell colSpan={visibleColumnCount} className="h-48">
+              <div role="alert">
+                <EmptyState title={errorTitle} description={errorDescription} />
               </div>
             </TableCell>
           </TableRow>

--- a/components/object/list.tsx
+++ b/components/object/list.tsx
@@ -87,6 +87,21 @@ interface ObjectRow {
   LastModified: string
 }
 
+type ObjectListError = "accessDenied" | "loadFailed"
+
+function isAccessDeniedError(error: unknown): boolean {
+  const serviceError = error as {
+    $metadata?: { httpStatusCode?: number }
+    Code?: string
+    name?: string
+    message?: string
+  }
+  if (serviceError?.$metadata?.httpStatusCode === 403) return true
+
+  const code = (serviceError?.Code ?? serviceError?.name ?? serviceError?.message ?? "").toLowerCase()
+  return code === "accessdenied" || code === "forbidden" || code.includes("access denied")
+}
+
 interface ObjectListProps {
   bucket: string
   path: string
@@ -123,12 +138,11 @@ export function ObjectList({
   const [searchTerm, setSearchTerm] = React.useState("")
   const [showDeleted, setShowDeleted] = useLocalStorage("object-list-show-deleted", false)
   const [loading, setLoading] = React.useState(false)
+  const [listError, setListError] = React.useState<ObjectListError | null>(null)
   const [data, setData] = React.useState<ObjectRow[]>([])
   const [nextToken, setNextToken] = React.useState<string | undefined>()
   const [showScrollShortcuts, setShowScrollShortcuts] = React.useState(false)
   const [bucketVersioningState, setBucketVersioningState] = React.useState<BucketVersioningState>("unknown")
-  const [versioningError, setVersioningError] = React.useState("")
-  const [versioningReload, setVersioningReload] = React.useState(0)
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
   const [deleteDialogKeys, setDeleteDialogKeys] = React.useState<string[]>([])
   const [deleteAllVersions, setDeleteAllVersions] = React.useState(false)
@@ -203,6 +217,7 @@ export function ObjectList({
       const requestScope = activeScopeRef.current
       loadingRef.current = true
       setLoading(true)
+      if (!shouldAppend) setListError(null)
       try {
         const response = await listObject(bucket, prefix || undefined, resolvedPageSize, token, {
           includeDeleted: showDeleted,
@@ -226,6 +241,7 @@ export function ObjectList({
         }
 
         setNextToken(r.NextContinuationToken)
+        setListError(null)
 
         const prefixItems: ObjectRow[] = (r.CommonPrefixes ?? []).map((item) => ({
           Key: item.Prefix ?? "",
@@ -261,6 +277,7 @@ export function ObjectList({
           setNextToken(undefined)
           if (!shouldAppend) {
             setData([])
+            setListError(isAccessDeniedError(error) ? "accessDenied" : "loadFailed")
           }
         }
       } finally {
@@ -327,7 +344,6 @@ export function ObjectList({
 
     const loadBucketVersioningStatus = async () => {
       setBucketVersioningState("unknown")
-      setVersioningError("")
 
       try {
         const resp = await getBucketVersioning(bucket)
@@ -338,7 +354,6 @@ export function ObjectList({
         console.error("Failed to load bucket versioning status:", error)
         if (!cancelled) {
           setBucketVersioningState("unknown")
-          setVersioningError(t("Failed to get data"))
         }
       }
     }
@@ -348,7 +363,7 @@ export function ObjectList({
     return () => {
       cancelled = true
     }
-  }, [bucket, getBucketVersioning, t, versioningReload])
+  }, [bucket, getBucketVersioning])
 
   const displayKey = React.useCallback(
     (key: string) => {
@@ -531,7 +546,6 @@ export function ObjectList({
                 size="sm"
                 onClick={() => openDeleteDialog([row.original.Key])}
                 disabled={bucketVersioningState === "unknown"}
-                aria-describedby={bucketVersioningState === "unknown" ? "object-versioning-status" : undefined}
               >
                 <RiDeleteBin5Line className="size-4" aria-hidden />
                 <span>{t("Delete")}</span>
@@ -781,7 +795,6 @@ export function ObjectList({
                     className="border-destructive text-destructive"
                     onClick={handleBatchDelete}
                     disabled={bucketVersioningState === "unknown"}
-                    aria-describedby={bucketVersioningState === "unknown" ? "object-versioning-status" : undefined}
                   >
                     <RiDeleteBin5Line className="size-4" aria-hidden />
                     <span>{t("Delete Selected")}</span>
@@ -824,44 +837,30 @@ export function ObjectList({
         </div>
       </PageHeader>
 
-      {bucketVersioningState === "unknown" ? (
-        <div
-          id="object-versioning-status"
-          role={versioningError ? "alert" : "status"}
-          className="flex flex-col gap-3 border border-border bg-muted/30 p-3 text-sm sm:flex-row sm:items-center sm:justify-between"
-        >
-          <span className={versioningError ? "text-destructive" : "text-muted-foreground"}>
-            {versioningError || t("Loading…")}
-          </span>
-          {versioningError ? (
-            <Button
-              type="button"
-              variant="outline"
-              className="w-full sm:w-auto"
-              onClick={() => setVersioningReload((value) => value + 1)}
-            >
-              <RiRefreshLine className="size-4" aria-hidden />
-              {t("Refresh")}
-            </Button>
-          ) : null}
-        </div>
-      ) : null}
-
       <DataTable
         table={table}
         isLoading={displayState === "loading" || displayState === "filtered-loading"}
+        errorTitle={
+          listError === "accessDenied"
+            ? t("Access Denied")
+            : listError === "loadFailed"
+              ? t("Failed to load objects")
+              : undefined
+        }
         emptyTitle={emptyTitle}
         emptyDescription={emptyDescription}
       />
 
-      <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
-        <span>
-          {t("Loaded {count} objects", {
-            count: data.length,
-          })}
-        </span>
-        <span>{t("Filtering and sorting apply to loaded objects")}</span>
-      </div>
+      {!listError ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
+          <span>
+            {t("Loaded {count} objects", {
+              count: data.length,
+            })}
+          </span>
+          <span>{t("Filtering and sorting apply to loaded objects")}</span>
+        </div>
+      ) : null}
 
       {nextToken ? (
         <div ref={loadMoreRef} className="flex min-h-10 items-center justify-center text-sm text-muted-foreground">

--- a/lib/bucket-access.ts
+++ b/lib/bucket-access.ts
@@ -1,0 +1,16 @@
+interface S3ServiceError {
+  $metadata?: {
+    httpStatusCode?: number
+  }
+  Code?: string
+  name?: string
+  message?: string
+}
+
+export function isMissingBucketError(error: unknown): boolean {
+  const serviceError = error as S3ServiceError
+  if (serviceError?.$metadata?.httpStatusCode === 404) return true
+
+  const code = (serviceError?.Code ?? serviceError?.name ?? "").toLowerCase()
+  return code === "nosuchbucket" || code === "notfound"
+}

--- a/lib/bucket-policy-status.ts
+++ b/lib/bucket-policy-status.ts
@@ -1,0 +1,23 @@
+export interface BucketPolicyStatusResponse {
+  PolicyStatus?: {
+    IsPublic?: boolean
+  }
+}
+
+export async function loadBucketPolicyStatuses(
+  bucketNames: string[],
+  getBucketPolicyStatus: (bucketName: string) => Promise<unknown>,
+): Promise<Record<string, boolean | undefined>> {
+  const results = await Promise.all(
+    bucketNames.map(async (name) => {
+      try {
+        const response = (await getBucketPolicyStatus(name)) as BucketPolicyStatusResponse
+        return [name, response.PolicyStatus?.IsPublic] as const
+      } catch {
+        return [name, undefined] as const
+      }
+    }),
+  )
+
+  return Object.fromEntries(results)
+}

--- a/tests/lib/bucket-access.test.ts
+++ b/tests/lib/bucket-access.test.ts
@@ -1,0 +1,17 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { isMissingBucketError } from "../../lib/bucket-access"
+
+test("isMissingBucketError redirects only for a definitive missing bucket response", () => {
+  assert.equal(isMissingBucketError({ $metadata: { httpStatusCode: 404 } }), true)
+  assert.equal(isMissingBucketError({ Code: "NoSuchBucket" }), true)
+})
+
+test("isMissingBucketError does not treat access denied as a missing bucket", () => {
+  assert.equal(isMissingBucketError({ $metadata: { httpStatusCode: 403 }, Code: "AccessDenied" }), false)
+})
+
+test("isMissingBucketError keeps the current bucket when availability is uncertain", () => {
+  assert.equal(isMissingBucketError(new Error("Network request failed")), false)
+})

--- a/tests/lib/bucket-policy-status.test.ts
+++ b/tests/lib/bucket-policy-status.test.ts
@@ -1,0 +1,27 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import { loadBucketPolicyStatuses } from "../../lib/bucket-policy-status"
+
+test("loadBucketPolicyStatuses preserves public and private responses", async () => {
+  const statuses = await loadBucketPolicyStatuses(["public", "private"], async (bucketName) => ({
+    PolicyStatus: { IsPublic: bucketName === "public" },
+  }))
+
+  assert.deepEqual(statuses, {
+    public: true,
+    private: false,
+  })
+})
+
+test("loadBucketPolicyStatuses leaves access-denied responses unknown", async () => {
+  const statuses = await loadBucketPolicyStatuses(["allowed", "denied"], async (bucketName) => {
+    if (bucketName === "denied") throw new Error("AccessDenied")
+    return { PolicyStatus: { IsPublic: false } }
+  })
+
+  assert.deepEqual(statuses, {
+    allowed: false,
+    denied: undefined,
+  })
+})

--- a/tests/lib/data-table-error-source.test.js
+++ b/tests/lib/data-table-error-source.test.js
@@ -1,0 +1,12 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+
+test("DataTable renders request failures as an announced error state before empty content", () => {
+  const source = fs.readFileSync("components/data-table/data-table.tsx", "utf8")
+
+  assert.match(source, /errorTitle\?: string/)
+  assert.match(source, /\) : errorTitle \? \(/)
+  assert.match(source, /<div role="alert">/)
+  assert.match(source, /<EmptyState title=\{errorTitle\} description=\{errorDescription\}/)
+})

--- a/tests/lib/object-delete-safety.test.js
+++ b/tests/lib/object-delete-safety.test.js
@@ -18,8 +18,7 @@ test("unknown bucket versioning state never enables force delete", () => {
 
 test("object deletion stays blocked until versioning state is known", () => {
   assert.match(objectListSource, /setBucketVersioningState\("unknown"\)/)
-  assert.match(objectListSource, /versioningError/)
   assert.match(objectListSource, /bucketVersioningState === "unknown"/)
-  assert.match(objectListSource, /role=\{versioningError \? "alert" : "status"\}/)
+  assert.doesNotMatch(objectListSource, /object-versioning-status/)
   assert.doesNotMatch(objectListSource, /catch\s*\{[\s\S]{0,120}setBucketVersioningState\("disabled"\)/)
 })

--- a/tests/lib/object-list-source.test.js
+++ b/tests/lib/object-list-source.test.js
@@ -10,12 +10,16 @@ test("object list normalizes LastModified through the safe date helper", () => {
   assert.equal(source.includes('item.LastModified ? item.LastModified.toISOString() : ""'), false)
 })
 
-test("object list falls back to an empty table instead of crashing the page on fetch errors", () => {
+test("object list distinguishes access errors from a confirmed empty bucket", () => {
   const source = fs.readFileSync("components/object/list.tsx", "utf8")
 
   assert.equal(source.includes('console.error("Failed to fetch objects:", error)'), true)
   assert.equal(source.includes('message.error((error as Error)?.message ?? t("Failed to load objects"))'), true)
   assert.equal(source.includes("setData([])"), true)
+  assert.equal(source.includes('setListError(isAccessDeniedError(error) ? "accessDenied" : "loadFailed")'), true)
+  assert.equal(source.includes('listError === "accessDenied"'), true)
+  assert.equal(source.includes('t("Access Denied")'), true)
+  assert.equal(source.includes("{!listError ? ("), true)
 })
 
 test("object list lazy loads additional object batches instead of showing a paginator", () => {


### PR DESCRIPTION
# Pull Request

## Description

Fix readonly bucket browsing so permission-limited S3 responses are represented accurately instead of redirecting users or inventing trusted state.

- Keep users on the bucket page when `HeadBucket` returns 403; only redirect for a definitive missing bucket response.
- Show unknown access policy as `-` when `GetBucketPolicyStatus` cannot be read instead of incorrectly labeling the bucket private.
- Keep `GetBucketVersioning` fail-closed for deletion safety without showing the generic `Failed to get data` banner.
- Distinguish object-list 403 and load failures from a confirmed empty bucket.
- Add an announced DataTable error state and preserve the upstream filtered-empty behavior.

The root cause was that independent permission failures were being collapsed into unrelated states: 403 from `HeadBucket` triggered navigation, policy-status failure became `false`, and object-list failure became an empty result.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed

```bash
pnpm install --frozen-lockfile
pnpm tsc --noEmit
pnpm lint
pnpm test:run
pnpm prettier --check <changed files>
git diff --check
```

373 tests pass. TypeScript, ESLint, changed-file Prettier, lockfile sync, and diff checks pass.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

None.

## Screenshots (if applicable)

Not included; the error states require permission-specific S3 responses.

## Additional Notes

The full-repository `pnpm prettier --check .` currently reports a pre-existing formatting issue in `app/(dashboard)/sse/page.tsx`. That file is not changed by this PR; all files changed here pass Prettier.