### PR TITLE
feat(sse): enable local KMS evaluation workflows

### DIFF
--- a/app/(dashboard)/sse/page.tsx
+++ b/app/(dashboard)/sse/page.tsx
@@ -41,6 +41,13 @@ import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, Tabl
 import { useSSE } from "@/hooks/use-sse"
 import { useMessage } from "@/lib/feedback/message"
 import { formatDateTime } from "@/lib/functions"
+import {
+  INITIAL_FORM_STATE,
+  buildFormStateFromStatus,
+  getFormSyncDecision,
+  isSafeLocalFilePermissions,
+  type ConfigFormState,
+} from "@/lib/sse/config"
 import type { KmsConfigPayload, KmsKeyInfo, KmsKeyMetadata, KmsServiceStatusResponse } from "@/types/kms"
 import {
   AlertDialog,
@@ -63,27 +70,6 @@ const ADVANCED_CONFIG_FIELDS = new Set([
   "cacheTtlSeconds",
 ])
 
-type ConfigFormState = {
-  backendType: "local" | "vault-kv2" | "vault-transit" | "static"
-  keyDir: string
-  filePermissions: string
-  defaultKeyId: string
-  timeoutSeconds: string
-  retryAttempts: string
-  enableCache: boolean
-  maxCachedKeys: string
-  cacheTtlSeconds: string
-  address: string
-  vaultToken: string
-  namespace: string
-  mountPath: string
-  kvMount: string
-  keyPathPrefix: string
-  skipTlsVerify: boolean
-  secretKey: string
-  staticKeyId: string
-}
-
 type KeyActionState = {
   type: "scheduleDelete" | "forceDelete" | "cancelDeletion"
   key: KmsKeyInfo
@@ -93,27 +79,6 @@ type PendingNavigation = {
   destination?: string
   historyDelta?: number
 } | null
-
-const INITIAL_FORM_STATE: ConfigFormState = {
-  backendType: "vault-transit",
-  keyDir: "",
-  filePermissions: "384",
-  defaultKeyId: "",
-  timeoutSeconds: "30",
-  retryAttempts: "3",
-  enableCache: true,
-  maxCachedKeys: "1000",
-  cacheTtlSeconds: "3600",
-  address: "",
-  vaultToken: "",
-  namespace: "",
-  mountPath: "transit",
-  kvMount: "secret",
-  keyPathPrefix: "rustfs/kms/keys",
-  skipTlsVerify: false,
-  secretKey: "",
-  staticKeyId: "",
-}
 
 function getStatusKind(status: KmsServiceStatusResponse | null): "NotConfigured" | "Configured" | "Running" | "Error" {
   if (!status?.status) return "NotConfigured"
@@ -151,50 +116,6 @@ function parseOptionalInteger(value: string) {
   return Number.isFinite(parsed) ? parsed : undefined
 }
 
-function normalizeBackendType(value?: string | null): ConfigFormState["backendType"] {
-  switch (value) {
-    case "Vault":
-    case "VaultKV2":
-      return "vault-kv2"
-    case "VaultTransit":
-      return "vault-transit"
-    case "Static":
-      return "static"
-    default:
-      return "local"
-  }
-}
-
-function buildFormStateFromStatus(status: KmsServiceStatusResponse | null): ConfigFormState {
-  if (!status) return INITIAL_FORM_STATE
-
-  const summary = status.config_summary
-  const backendSummary = summary?.backend_summary
-  const cacheSummary = summary?.cache_summary
-  const backendType = normalizeBackendType(status.backend_type ?? summary?.backend_type)
-
-  return {
-    backendType,
-    keyDir: backendSummary?.key_dir ?? "",
-    filePermissions: String(backendSummary?.file_permissions ?? 384),
-    defaultKeyId: summary?.default_key_id ?? "",
-    timeoutSeconds: String(summary?.timeout_seconds ?? 30),
-    retryAttempts: String(summary?.retry_attempts ?? 3),
-    enableCache: summary?.enable_cache ?? cacheSummary?.enabled ?? true,
-    maxCachedKeys: String(summary?.max_cached_keys ?? cacheSummary?.max_keys ?? 1000),
-    cacheTtlSeconds: String(summary?.cache_ttl_seconds ?? cacheSummary?.ttl_seconds ?? 3600),
-    address: backendSummary?.address ?? "",
-    vaultToken: "",
-    namespace: backendSummary?.namespace ?? "",
-    mountPath: backendSummary?.mount_path ?? "transit",
-    kvMount: backendSummary?.kv_mount ?? "secret",
-    keyPathPrefix: backendSummary?.key_path_prefix ?? "rustfs/kms/keys",
-    secretKey: "",
-    staticKeyId: backendSummary?.key_id ?? "",
-    skipTlsVerify: backendSummary?.skip_tls_verify ?? false,
-  }
-}
-
 export default function SSEPage() {
   const { t } = useTranslation()
   const message = useMessage()
@@ -220,6 +141,9 @@ export default function SSEPage() {
   const [baselineFormState, setBaselineFormState] = React.useState<ConfigFormState>(INITIAL_FORM_STATE)
   const [configFormError, setConfigFormError] = React.useState<string | null>(null)
   const [configFormErrorField, setConfigFormErrorField] = React.useState<string | null>(null)
+  const [configBaselineConflict, setConfigBaselineConflict] = React.useState<string | null>(null)
+  const formStateRef = React.useRef(formState)
+  const baselineFormStateRef = React.useRef(baselineFormState)
   const advancedSettingsRef = React.useRef<HTMLDetailsElement>(null)
   const [loadingStatus, setLoadingStatus] = React.useState(false)
   const [refreshingStatus, setRefreshingStatus] = React.useState(false)
@@ -280,6 +204,37 @@ export default function SSEPage() {
   const statusBadgeValue =
     statusKind === "Error" ? "Error" : typeof status?.status === "string" ? status.status : statusKind
 
+  React.useEffect(() => {
+    formStateRef.current = formState
+  }, [formState])
+
+  React.useEffect(() => {
+    baselineFormStateRef.current = baselineFormState
+  }, [baselineFormState])
+
+  const applyStatusToForm = React.useCallback(
+    (nextStatus: KmsServiceStatusResponse | null, force = false) => {
+      const nextFormState = buildFormStateFromStatus(nextStatus)
+      const decision = force
+        ? "sync"
+        : getFormSyncDecision(formStateRef.current, baselineFormStateRef.current, nextFormState)
+
+      if (decision === "sync") {
+        setFormState(nextFormState)
+        setBaselineFormState(nextFormState)
+        setConfigBaselineConflict(null)
+        return
+      }
+
+      if (decision === "conflict") {
+        setConfigBaselineConflict(
+          t("KMS configuration changed on the server. Reset the form to the current status before saving."),
+        )
+      }
+    },
+    [t],
+  )
+
   const loadStatus = React.useCallback(
     async (syncForm = false) => {
       const requestId = ++statusRequestRef.current
@@ -290,11 +245,7 @@ export default function SSEPage() {
         if (requestId !== statusRequestRef.current) return res
         setStatus(res)
         setStatusError(null)
-        if (syncForm) {
-          const nextFormState = buildFormStateFromStatus(res)
-          setFormState(nextFormState)
-          setBaselineFormState(nextFormState)
-        }
+        applyStatusToForm(res, syncForm)
         return res
       } catch (error) {
         if (requestId !== statusRequestRef.current) throw error
@@ -305,7 +256,7 @@ export default function SSEPage() {
         if (requestId === statusRequestRef.current) setLoadingStatus(false)
       }
     },
-    [getKMSStatus, t],
+    [applyStatusToForm, getKMSStatus, t],
   )
 
   const loadKeys = React.useCallback(
@@ -450,6 +401,7 @@ export default function SSEPage() {
     setBaselineFormState(nextFormState)
     setConfigFormError(null)
     setConfigFormErrorField(null)
+    setConfigBaselineConflict(null)
   }
 
   const discardConfigChangesAndNavigate = () => {
@@ -537,11 +489,26 @@ export default function SSEPage() {
       const maxCachedKeys = parseOptionalInteger(values.maxCachedKeys)
       const cacheTtlSeconds = parseOptionalInteger(values.cacheTtlSeconds)
 
+      if (values.backendType === "unsupported") {
+        return {
+          error: t(
+            "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+          ),
+          field: "kmsBackend",
+        }
+      }
+
       if (values.backendType === "local") {
         if (!values.keyDir.trim()) {
           return { error: t("Please enter an absolute local key directory path"), field: "keyDir" }
         }
         const filePermissions = parseOptionalInteger(values.filePermissions)
+        if (filePermissions != null && !isSafeLocalFilePermissions(filePermissions)) {
+          return {
+            error: t("Local KMS key files must use owner-only permissions such as 384 for 0o600."),
+            field: "filePermissions",
+          }
+        }
         return {
           payload: {
             backend_type: "Local",
@@ -638,6 +605,12 @@ export default function SSEPage() {
         if (source === "manual") message.error(t("Failed to load KMS status"))
         return false
       }
+      if (configBaselineConflict) {
+        setConfigFormError(configBaselineConflict)
+        setConfigFormErrorField(null)
+        if (source === "manual") message.error(configBaselineConflict)
+        return false
+      }
       const nestedCreateMutation = source === "defaultKey" && mutationRef.current === "create-key"
       const ownsMutation = nestedCreateMutation || beginMutation("kms-config")
       if (!ownsMutation) return false
@@ -702,6 +675,7 @@ export default function SSEPage() {
     [
       beginMutation,
       buildConfigPayload,
+      configBaselineConflict,
       configureKMS,
       endMutation,
       loadStatus,
@@ -852,9 +826,13 @@ export default function SSEPage() {
       if (createKeySetAsDefault && createdKeyId) {
         const updated = await submitConfiguration(createdKeyId, "defaultKey", buildFormStateFromStatus(status))
         if (!updated) {
-          message.warning(
-            t("Key created but could not update the default SSE key. Save the configuration form and try again."),
+          const recoveryMessage = t(
+            "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.",
           )
+          setFormState((current) => ({ ...current, defaultKeyId: createdKeyId }))
+          setConfigFormError(recoveryMessage)
+          setConfigFormErrorField("defaultKeyId")
+          message.warning(recoveryMessage)
         }
       }
 
@@ -959,10 +937,19 @@ export default function SSEPage() {
   const isPendingDefaultKey = pendingKeyAction?.key.key_id === status?.config_summary?.default_key_id
 
   const mutationLocked = Boolean(activeMutation || statusError || loadingStatus)
+  const unsupportedKmsReadOnly = formState.backendType === "unsupported"
   const staticKmsReadOnly = hasConfiguration && formState.backendType === "static"
-  const formDisabled = mutationLocked || loadingStatus || submittingConfig || staticKmsReadOnly
+  const formDisabled =
+    mutationLocked ||
+    loadingStatus ||
+    submittingConfig ||
+    Boolean(configBaselineConflict) ||
+    unsupportedKmsReadOnly ||
+    staticKmsReadOnly
   const mutationInFlight = Boolean(activeMutation || submittingConfig || creatingKey || processingKeyAction)
-  const canSetCreatedKeyAsDefault = status?.backend_type !== "Static" && !isConfigDirty
+  const canSetCreatedKeyAsDefault = status?.backend_type !== "Static" && !isConfigDirty && !configBaselineConflict
+  const resetDisabled =
+    mutationLocked || loadingStatus || submittingConfig || (!isConfigDirty && !configBaselineConflict)
 
   return (
     <>
@@ -1121,6 +1108,12 @@ export default function SSEPage() {
                   <AlertDescription id="kms-config-error">{configFormError}</AlertDescription>
                 </Alert>
               ) : null}
+              {configBaselineConflict ? (
+                <Alert variant="destructive" role="alert">
+                  <AlertTitle>{t("KMS configuration changed")}</AlertTitle>
+                  <AlertDescription>{configBaselineConflict}</AlertDescription>
+                </Alert>
+              ) : null}
               {formState.backendType === "local" ? (
                 <Alert>
                   <AlertTitle>{t("Warning")}</AlertTitle>
@@ -1132,6 +1125,16 @@ export default function SSEPage() {
                       : t(
                           "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.",
                         )}
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+              {unsupportedKmsReadOnly ? (
+                <Alert variant="destructive">
+                  <AlertTitle>{t("Unsupported KMS backend")}</AlertTitle>
+                  <AlertDescription>
+                    {t(
+                      "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+                    )}
                   </AlertDescription>
                 </Alert>
               ) : null}
@@ -1160,6 +1163,11 @@ export default function SSEPage() {
                             <SelectValue placeholder={t("Select backend type")} />
                           </SelectTrigger>
                           <SelectContent>
+                            {formState.backendType === "unsupported" ? (
+                              <SelectItem value="unsupported" disabled>
+                                {t("Unsupported KMS backend")}
+                              </SelectItem>
+                            ) : null}
                             <SelectItem value="local">{t("Local filesystem")}</SelectItem>
                             <SelectItem value="vault-kv2">{t("HashiCorp Vault KV2")}</SelectItem>
                             <SelectItem value="vault-transit">{t("HashiCorp Vault Transit Engine")}</SelectItem>
@@ -1195,11 +1203,20 @@ export default function SSEPage() {
                   <legend className="pe-2 text-sm font-semibold">
                     {formState.backendType === "local"
                       ? t("Local filesystem")
-                      : formState.backendType === "static"
-                        ? t("Static key configuration")
-                        : t("Vault connection")}
+                      : formState.backendType === "unsupported"
+                        ? t("Unsupported KMS backend")
+                        : formState.backendType === "static"
+                          ? t("Static key configuration")
+                          : t("Vault connection")}
                   </legend>
-                  {formState.backendType === "static" ? (
+                  {formState.backendType === "unsupported" ? (
+                    <Alert variant="destructive">
+                      <AlertTitle>{t("Unsupported KMS backend")}</AlertTitle>
+                      <AlertDescription>
+                        {t("Console cannot safely edit a newer or unknown KMS backend type.")}
+                      </AlertDescription>
+                    </Alert>
+                  ) : formState.backendType === "static" ? (
                     <FieldGroup className="grid gap-4 lg:grid-cols-2">
                       <Field>
                         <FieldLabel htmlFor="secretKey">{t("Secret Key")}</FieldLabel>
@@ -1530,12 +1547,7 @@ export default function SSEPage() {
                 </details>
 
                 <div className="flex flex-wrap items-center justify-end gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={resetFormToCurrentStatus}
-                    disabled={formDisabled || !isConfigDirty}
-                  >
+                  <Button type="button" variant="outline" onClick={resetFormToCurrentStatus} disabled={resetDisabled}>
                     {t("Reset to Current Status")}
                   </Button>
                   <Button type="submit" disabled={formDisabled || !isConfigDirty}>

--- a/app/(dashboard)/sse/page.tsx
+++ b/app/(dashboard)/sse/page.tsx
@@ -273,7 +273,10 @@ export default function SSEPage() {
   const statusKind = React.useMemo(() => (statusError ? "Error" : getStatusKind(status)), [status, statusError])
   const isRunning = statusKind === "Running"
   const hasConfiguration = !statusError && statusKind !== "NotConfigured"
+  const localKmsConfigured = hasConfiguration && status?.backend_type === "Local"
   const hasStoredVaultCredentials = status?.config_summary?.backend_summary?.has_stored_credentials === true
+  const hasStoredLocalMasterKey = status?.config_summary?.backend_summary?.has_master_key === true
+  const hasStoredLocalFilePermissions = status?.config_summary?.backend_summary?.file_permissions != null
   const statusBadgeValue =
     statusKind === "Error" ? "Error" : typeof status?.status === "string" ? status.status : statusKind
 
@@ -535,19 +538,31 @@ export default function SSEPage() {
       const cacheTtlSeconds = parseOptionalInteger(values.cacheTtlSeconds)
 
       if (values.backendType === "local") {
+        if (!values.keyDir.trim()) {
+          return { error: t("Please enter an absolute local key directory path"), field: "keyDir" }
+        }
+        const filePermissions = parseOptionalInteger(values.filePermissions)
         return {
-          error: t(
-            "Local filesystem KMS configuration is read-only in Console until safe master-key rotation is available.",
-          ),
+          payload: {
+            backend_type: "Local",
+            key_dir: values.keyDir.trim(),
+            file_permissions:
+              localKmsConfigured && !hasStoredLocalFilePermissions ? undefined : (filePermissions ?? 384),
+            allow_insecure_dev_defaults: !hasStoredLocalMasterKey,
+            default_key_id: defaultKeyId || undefined,
+            timeout_seconds: timeoutSeconds ?? 30,
+            retry_attempts: retryAttempts ?? 3,
+            enable_cache: values.enableCache,
+            max_cached_keys: values.enableCache ? (maxCachedKeys ?? 1000) : undefined,
+            cache_ttl_seconds: values.enableCache ? (cacheTtlSeconds ?? 3600) : undefined,
+          },
         }
       }
 
       if (values.backendType === "static") {
         if (!values.secretKey.trim()) {
           return {
-            error: t(
-              "Please enter the static KMS secret key (base64-encoded 32-byte AES-256 key).",
-            ),
+            error: t("Please enter the static KMS secret key (base64-encoded 32-byte AES-256 key)."),
             field: "secretKey",
           }
         }
@@ -603,7 +618,14 @@ export default function SSEPage() {
         },
       }
     },
-    [formState, hasStoredVaultCredentials, t],
+    [
+      formState,
+      hasStoredLocalFilePermissions,
+      hasStoredLocalMasterKey,
+      hasStoredVaultCredentials,
+      localKmsConfigured,
+      t,
+    ],
   )
 
   const submitConfiguration = React.useCallback(
@@ -937,12 +959,10 @@ export default function SSEPage() {
   const isPendingDefaultKey = pendingKeyAction?.key.key_id === status?.config_summary?.default_key_id
 
   const mutationLocked = Boolean(activeMutation || statusError || loadingStatus)
-  const localKmsReadOnly = hasConfiguration && formState.backendType === "local"
   const staticKmsReadOnly = hasConfiguration && formState.backendType === "static"
-  const formDisabled = mutationLocked || loadingStatus || submittingConfig || localKmsReadOnly || staticKmsReadOnly
+  const formDisabled = mutationLocked || loadingStatus || submittingConfig || staticKmsReadOnly
   const mutationInFlight = Boolean(activeMutation || submittingConfig || creatingKey || processingKeyAction)
-  const canSetCreatedKeyAsDefault =
-    status?.backend_type !== "Local" && status?.backend_type !== "Static" && !isConfigDirty
+  const canSetCreatedKeyAsDefault = status?.backend_type !== "Static" && !isConfigDirty
 
   return (
     <>
@@ -1101,13 +1121,17 @@ export default function SSEPage() {
                   <AlertDescription id="kms-config-error">{configFormError}</AlertDescription>
                 </Alert>
               ) : null}
-              {localKmsReadOnly ? (
+              {formState.backendType === "local" ? (
                 <Alert>
-                  <AlertTitle>{t("Local filesystem")}</AlertTitle>
+                  <AlertTitle>{t("Warning")}</AlertTitle>
                   <AlertDescription>
-                    {t(
-                      "Local filesystem KMS configuration is read-only in Console until safe master-key rotation is available.",
-                    )}
+                    {localKmsConfigured
+                      ? t(
+                          "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.",
+                        )
+                      : t(
+                          "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.",
+                        )}
                   </AlertDescription>
                 </Alert>
               ) : null}
@@ -1130,15 +1154,13 @@ export default function SSEPage() {
                           onValueChange={(value) =>
                             updateFormState("backendType", value as ConfigFormState["backendType"])
                           }
-                          disabled={formDisabled}
+                          disabled={formDisabled || localKmsConfigured}
                         >
                           <SelectTrigger id="kmsBackend" className="w-full" aria-label={t("KMS Backend")}>
                             <SelectValue placeholder={t("Select backend type")} />
                           </SelectTrigger>
                           <SelectContent>
-                            <SelectItem value="local" disabled>
-                              {t("Local filesystem")}
-                            </SelectItem>
+                            <SelectItem value="local">{t("Local filesystem")}</SelectItem>
                             <SelectItem value="vault-kv2">{t("HashiCorp Vault KV2")}</SelectItem>
                             <SelectItem value="vault-transit">{t("HashiCorp Vault Transit Engine")}</SelectItem>
                             <SelectItem value="static">{t("Static single-key (built-in)")}</SelectItem>
@@ -1216,7 +1238,7 @@ export default function SSEPage() {
                             autoComplete="off"
                             placeholder={t("Enter an absolute path such as D:/data/kms-keys")}
                             spellCheck={false}
-                            disabled={formDisabled}
+                            disabled={formDisabled || localKmsConfigured}
                             required
                             aria-required="true"
                             aria-invalid={configFormErrorField === "keyDir"}
@@ -1241,7 +1263,7 @@ export default function SSEPage() {
                             value={formState.filePermissions}
                             onChange={(event) => updateFormState("filePermissions", event.target.value)}
                             placeholder="384"
-                            disabled={formDisabled}
+                            disabled={formDisabled || localKmsConfigured}
                           />
                         </FieldContent>
                         <FieldDescription>{t("Use decimal values such as 384 for 0o600.")}</FieldDescription>
@@ -1532,7 +1554,7 @@ export default function SSEPage() {
                   <div className="space-y-1">
                     <h2 className="text-base font-semibold sm:text-lg">{t("KMS Keys Management")}</h2>
                     <CardDescription>
-                      {t("Create, rotate, and inspect the keys managed by your KMS backend.")}
+                      {t("Create a new KMS key and optionally make it the default SSE key.")}
                     </CardDescription>
                   </div>
                   <div className="flex flex-wrap items-center gap-2">
@@ -1548,7 +1570,13 @@ export default function SSEPage() {
                     <Button
                       size="sm"
                       onClick={() => setCreateKeyOpen(true)}
-                      disabled={Boolean(activeMutation) || loadingKeys || loadingStatus || Boolean(keysError) || staticKmsReadOnly}
+                      disabled={
+                        Boolean(activeMutation) ||
+                        loadingKeys ||
+                        loadingStatus ||
+                        Boolean(keysError) ||
+                        staticKmsReadOnly
+                      }
                     >
                       <RiAddLine className="size-4" aria-hidden />
                       {t("Create Key")}
@@ -1642,7 +1670,11 @@ export default function SSEPage() {
                                   variant="outline"
                                   className="min-h-11 flex-1 sm:flex-none"
                                   disabled={
-                                    isDefaultKey || Boolean(activeMutation) || loadingStatus || Boolean(keysError) || staticKmsReadOnly
+                                    isDefaultKey ||
+                                    Boolean(activeMutation) ||
+                                    loadingStatus ||
+                                    Boolean(keysError) ||
+                                    staticKmsReadOnly
                                   }
                                   onClick={() => setPendingKeyAction({ type: "scheduleDelete", key })}
                                 >
@@ -1654,7 +1686,11 @@ export default function SSEPage() {
                                 variant="destructive"
                                 className="min-h-11 flex-1 sm:flex-none"
                                 disabled={
-                                  isDefaultKey || Boolean(activeMutation) || loadingStatus || Boolean(keysError) || staticKmsReadOnly
+                                  isDefaultKey ||
+                                  Boolean(activeMutation) ||
+                                  loadingStatus ||
+                                  Boolean(keysError) ||
+                                  staticKmsReadOnly
                                 }
                                 onClick={() => setPendingKeyAction({ type: "forceDelete", key })}
                               >
@@ -1878,10 +1914,10 @@ export default function SSEPage() {
               <label htmlFor="setAsDefaultKey" className="space-y-1 text-sm">
                 <span className="block font-medium">{t("Set as default SSE key")}</span>
                 <span className="block text-xs text-muted-foreground">
-                  {status?.backend_type === "Local"
-                    ? t("Set a default key for Local KMS in server configuration.")
-                    : isConfigDirty
-                      ? t("Save or discard KMS configuration changes before setting a newly created default key.")
+                  {isConfigDirty
+                    ? t("Save or discard KMS configuration changes before setting a newly created default key.")
+                    : status?.backend_type === "Local"
+                      ? t("This will update the current KMS configuration after key creation.")
                       : t("This will update the current KMS configuration after key creation.")}
                 </span>
               </label>

--- a/i18n/locales/ar-MA.json
+++ b/i18n/locales/ar-MA.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "Unable to cancel transition job",
   "Unable to load transition job": "Unable to load transition job",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "خدمة KMS المحلية مخصصة للتقييم فقط. تُخزَّن المفاتيح التي تُنشأ من دون مفتاح رئيسي يديره الخادم كنص صريح في وضع التطوير. لا تستخدم هذه الواجهة الخلفية لبيانات الإنتاج.",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "خدمة KMS المحلية مخصصة للتقييم فقط. يُقفل دليل المفاتيح وأذونات الملفات بعد الإعداد، ولا يُدعم تغيير المفتاح الرئيسي المحلي أو تدويره."
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "خدمة KMS المحلية مخصصة للتقييم فقط. يُقفل دليل المفاتيح وأذونات الملفات بعد الإعداد، ولا يُدعم تغيير المفتاح الرئيسي المحلي أو تدويره.",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/ar-MA.json
+++ b/i18n/locales/ar-MA.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "Transition job started",
   "Transitioned": "Transitioned",
   "Unable to cancel transition job": "Unable to cancel transition job",
-  "Unable to load transition job": "Unable to load transition job"
+  "Unable to load transition job": "Unable to load transition job",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "خدمة KMS المحلية مخصصة للتقييم فقط. تُخزَّن المفاتيح التي تُنشأ من دون مفتاح رئيسي يديره الخادم كنص صريح في وضع التطوير. لا تستخدم هذه الواجهة الخلفية لبيانات الإنتاج.",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "خدمة KMS المحلية مخصصة للتقييم فقط. يُقفل دليل المفاتيح وأذونات الملفات بعد الإعداد، ولا يُدعم تغيير المفتاح الرئيسي المحلي أو تدويره."
 }

--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "Transition job started",
   "Transitioned": "Transitioned",
   "Unable to cancel transition job": "Unable to cancel transition job",
-  "Unable to load transition job": "Unable to load transition job"
+  "Unable to load transition job": "Unable to load transition job",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS ist nur zur Evaluierung vorgesehen. Schlüssel ohne serververwalteten Hauptschlüssel werden im Klartext-Entwicklungsmodus gespeichert. Verwenden Sie dieses Backend nicht für Produktionsdaten.",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS ist nur zur Evaluierung vorgesehen. Schlüsselverzeichnis und Dateiberechtigungen sind nach der Konfiguration gesperrt; das Ändern oder Rotieren des lokalen Hauptschlüssels wird nicht unterstützt."
 }

--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "Unable to cancel transition job",
   "Unable to load transition job": "Unable to load transition job",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS ist nur zur Evaluierung vorgesehen. Schlüssel ohne serververwalteten Hauptschlüssel werden im Klartext-Entwicklungsmodus gespeichert. Verwenden Sie dieses Backend nicht für Produktionsdaten.",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS ist nur zur Evaluierung vorgesehen. Schlüsselverzeichnis und Dateiberechtigungen sind nach der Konfiguration gesperrt; das Ändern oder Rotieren des lokalen Hauptschlüssels wird nicht unterstützt."
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS ist nur zur Evaluierung vorgesehen. Schlüsselverzeichnis und Dateiberechtigungen sind nach der Konfiguration gesperrt; das Ändern oder Rotieren des lokalen Hauptschlüssels wird nicht unterstützt.",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "Unable to cancel transition job",
   "Unable to load transition job": "Unable to load transition job",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported."
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "Transition job started",
   "Transitioned": "Transitioned",
   "Unable to cancel transition job": "Unable to cancel transition job",
-  "Unable to load transition job": "Unable to load transition job"
+  "Unable to load transition job": "Unable to load transition job",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported."
 }

--- a/i18n/locales/es-ES.json
+++ b/i18n/locales/es-ES.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "Transition job started",
   "Transitioned": "Transitioned",
   "Unable to cancel transition job": "Unable to cancel transition job",
-  "Unable to load transition job": "Unable to load transition job"
+  "Unable to load transition job": "Unable to load transition job",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS está destinado únicamente a evaluación. Las claves creadas sin una clave maestra gestionada por el servidor se almacenan en modo de desarrollo de texto sin formato. No use este backend para datos de producción.",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS está destinado únicamente a evaluación. El directorio de claves y los permisos de archivo quedan bloqueados tras la configuración; no se admite cambiar ni rotar la clave maestra local."
 }

--- a/i18n/locales/es-ES.json
+++ b/i18n/locales/es-ES.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "Unable to cancel transition job",
   "Unable to load transition job": "Unable to load transition job",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS está destinado únicamente a evaluación. Las claves creadas sin una clave maestra gestionada por el servidor se almacenan en modo de desarrollo de texto sin formato. No use este backend para datos de producción.",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS está destinado únicamente a evaluación. El directorio de claves y los permisos de archivo quedan bloqueados tras la configuración; no se admite cambiar ni rotar la clave maestra local."
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS está destinado únicamente a evaluación. El directorio de claves y los permisos de archivo quedan bloqueados tras la configuración; no se admite cambiar ni rotar la clave maestra local.",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "Transition job started",
   "Transitioned": "Transitioned",
   "Unable to cancel transition job": "Unable to cancel transition job",
-  "Unable to load transition job": "Unable to load transition job"
+  "Unable to load transition job": "Unable to load transition job",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS est réservé à l’évaluation. Les clés créées sans clé principale gérée par le serveur sont stockées en clair en mode développement. N’utilisez pas ce backend pour des données de production.",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS est réservé à l’évaluation. Le répertoire des clés et les permissions de fichiers sont verrouillés après la configuration ; la modification ou la rotation de la clé principale locale n’est pas prise en charge."
 }

--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "Unable to cancel transition job",
   "Unable to load transition job": "Unable to load transition job",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS est réservé à l’évaluation. Les clés créées sans clé principale gérée par le serveur sont stockées en clair en mode développement. N’utilisez pas ce backend pour des données de production.",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS est réservé à l’évaluation. Le répertoire des clés et les permissions de fichiers sont verrouillés après la configuration ; la modification ou la rotation de la clé principale locale n’est pas prise en charge."
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS est réservé à l’évaluation. Le répertoire des clés et les permissions de fichiers sont verrouillés après la configuration ; la modification ou la rotation de la clé principale locale n’est pas prise en charge.",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/id-ID.json
+++ b/i18n/locales/id-ID.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "Transition job started",
   "Transitioned": "Transitioned",
   "Unable to cancel transition job": "Unable to cancel transition job",
-  "Unable to load transition job": "Unable to load transition job"
+  "Unable to load transition job": "Unable to load transition job",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS hanya ditujukan untuk evaluasi. Kunci yang dibuat tanpa kunci utama yang dikelola server disimpan dalam mode pengembangan teks biasa. Jangan gunakan backend ini untuk data produksi.",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS hanya ditujukan untuk evaluasi. Direktori kunci dan izin file dikunci setelah konfigurasi; perubahan atau rotasi kunci utama lokal tidak didukung."
 }

--- a/i18n/locales/id-ID.json
+++ b/i18n/locales/id-ID.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "Unable to cancel transition job",
   "Unable to load transition job": "Unable to load transition job",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS hanya ditujukan untuk evaluasi. Kunci yang dibuat tanpa kunci utama yang dikelola server disimpan dalam mode pengembangan teks biasa. Jangan gunakan backend ini untuk data produksi.",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS hanya ditujukan untuk evaluasi. Direktori kunci dan izin file dikunci setelah konfigurasi; perubahan atau rotasi kunci utama lokal tidak didukung."
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS hanya ditujukan untuk evaluasi. Direktori kunci dan izin file dikunci setelah konfigurasi; perubahan atau rotasi kunci utama lokal tidak didukung.",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/it-IT.json
+++ b/i18n/locales/it-IT.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "Transition job started",
   "Transitioned": "Transitioned",
   "Unable to cancel transition job": "Unable to cancel transition job",
-  "Unable to load transition job": "Unable to load transition job"
+  "Unable to load transition job": "Unable to load transition job",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS è destinato esclusivamente alla valutazione. Le chiavi create senza una chiave master gestita dal server vengono archiviate in modalità di sviluppo in chiaro. Non utilizzare questo backend per dati di produzione.",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS è destinato esclusivamente alla valutazione. La directory delle chiavi e i permessi dei file vengono bloccati dopo la configurazione; la modifica o rotazione della chiave master locale non è supportata."
 }

--- a/i18n/locales/it-IT.json
+++ b/i18n/locales/it-IT.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "Unable to cancel transition job",
   "Unable to load transition job": "Unable to load transition job",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS è destinato esclusivamente alla valutazione. Le chiavi create senza una chiave master gestita dal server vengono archiviate in modalità di sviluppo in chiaro. Non utilizzare questo backend per dati di produzione.",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS è destinato esclusivamente alla valutazione. La directory delle chiavi e i permessi dei file vengono bloccati dopo la configurazione; la modifica o rotazione della chiave master locale non è supportata."
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS è destinato esclusivamente alla valutazione. La directory delle chiavi e i permessi dei file vengono bloccati dopo la configurazione; la modifica o rotazione della chiave master locale non è supportata.",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/ja-JP.json
+++ b/i18n/locales/ja-JP.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "Transition job started",
   "Transitioned": "Transitioned",
   "Unable to cancel transition job": "Unable to cancel transition job",
-  "Unable to load transition job": "Unable to load transition job"
+  "Unable to load transition job": "Unable to load transition job",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS は評価専用です。サーバー管理のマスターキーなしで作成されたキーは、平文の開発モードで保存されます。このバックエンドを本番データに使用しないでください。",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS は評価専用です。設定後はキーディレクトリとファイル権限が固定され、ローカルマスターキーの変更やローテーションはサポートされません。"
 }

--- a/i18n/locales/ja-JP.json
+++ b/i18n/locales/ja-JP.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "Unable to cancel transition job",
   "Unable to load transition job": "Unable to load transition job",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS は評価専用です。サーバー管理のマスターキーなしで作成されたキーは、平文の開発モードで保存されます。このバックエンドを本番データに使用しないでください。",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS は評価専用です。設定後はキーディレクトリとファイル権限が固定され、ローカルマスターキーの変更やローテーションはサポートされません。"
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS は評価専用です。設定後はキーディレクトリとファイル権限が固定され、ローカルマスターキーの変更やローテーションはサポートされません。",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/ko-KR.json
+++ b/i18n/locales/ko-KR.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "Unable to cancel transition job",
   "Unable to load transition job": "Unable to load transition job",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS는 평가 전용입니다. 서버 관리 마스터 키 없이 생성된 키는 평문 개발 모드로 저장됩니다. 이 백엔드를 프로덕션 데이터에 사용하지 마십시오.",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS는 평가 전용입니다. 구성 후 키 디렉터리와 파일 권한이 잠기며 로컬 마스터 키 변경이나 교체는 지원되지 않습니다."
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS는 평가 전용입니다. 구성 후 키 디렉터리와 파일 권한이 잠기며 로컬 마스터 키 변경이나 교체는 지원되지 않습니다.",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/ko-KR.json
+++ b/i18n/locales/ko-KR.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "Transition job started",
   "Transitioned": "Transitioned",
   "Unable to cancel transition job": "Unable to cancel transition job",
-  "Unable to load transition job": "Unable to load transition job"
+  "Unable to load transition job": "Unable to load transition job",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS는 평가 전용입니다. 서버 관리 마스터 키 없이 생성된 키는 평문 개발 모드로 저장됩니다. 이 백엔드를 프로덕션 데이터에 사용하지 마십시오.",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS는 평가 전용입니다. 구성 후 키 디렉터리와 파일 권한이 잠기며 로컬 마스터 키 변경이나 교체는 지원되지 않습니다."
 }

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "Unable to cancel transition job",
   "Unable to load transition job": "Unable to load transition job",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "O Local KMS destina-se apenas à avaliação. As chaves criadas sem uma chave mestra gerenciada pelo servidor são armazenadas no modo de desenvolvimento em texto simples. Não use este backend para dados de produção.",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "O Local KMS destina-se apenas à avaliação. O diretório de chaves e as permissões de arquivo ficam bloqueados após a configuração; não há suporte para alterar ou rotacionar a chave mestra local."
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "O Local KMS destina-se apenas à avaliação. O diretório de chaves e as permissões de arquivo ficam bloqueados após a configuração; não há suporte para alterar ou rotacionar a chave mestra local.",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "Transition job started",
   "Transitioned": "Transitioned",
   "Unable to cancel transition job": "Unable to cancel transition job",
-  "Unable to load transition job": "Unable to load transition job"
+  "Unable to load transition job": "Unable to load transition job",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "O Local KMS destina-se apenas à avaliação. As chaves criadas sem uma chave mestra gerenciada pelo servidor são armazenadas no modo de desenvolvimento em texto simples. Não use este backend para dados de produção.",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "O Local KMS destina-se apenas à avaliação. O diretório de chaves e as permissões de arquivo ficam bloqueados após a configuração; não há suporte para alterar ou rotacionar a chave mestra local."
 }

--- a/i18n/locales/ru-RU.json
+++ b/i18n/locales/ru-RU.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "Transition job started",
   "Transitioned": "Transitioned",
   "Unable to cancel transition job": "Unable to cancel transition job",
-  "Unable to load transition job": "Unable to load transition job"
+  "Unable to load transition job": "Unable to load transition job",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS предназначен только для ознакомления. Ключи, созданные без главного ключа под управлением сервера, хранятся в открытом виде в режиме разработки. Не используйте этот бэкенд для производственных данных.",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS предназначен только для ознакомления. Каталог ключей и права доступа к файлам блокируются после настройки; изменение или ротация локального главного ключа не поддерживается."
 }

--- a/i18n/locales/ru-RU.json
+++ b/i18n/locales/ru-RU.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "Unable to cancel transition job",
   "Unable to load transition job": "Unable to load transition job",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS предназначен только для ознакомления. Ключи, созданные без главного ключа под управлением сервера, хранятся в открытом виде в режиме разработки. Не используйте этот бэкенд для производственных данных.",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS предназначен только для ознакомления. Каталог ключей и права доступа к файлам блокируются после настройки; изменение или ротация локального главного ключа не поддерживается."
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS предназначен только для ознакомления. Каталог ключей и права доступа к файлам блокируются после настройки; изменение или ротация локального главного ключа не поддерживается.",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/tr-TR.json
+++ b/i18n/locales/tr-TR.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "Transition job started",
   "Transitioned": "Transitioned",
   "Unable to cancel transition job": "Unable to cancel transition job",
-  "Unable to load transition job": "Unable to load transition job"
+  "Unable to load transition job": "Unable to load transition job",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS yalnızca değerlendirme amacıyla kullanılmalıdır. Sunucu tarafından yönetilen bir ana anahtar olmadan oluşturulan anahtarlar düz metin geliştirme modunda saklanır. Bu arka ucu üretim verileri için kullanmayın.",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS yalnızca değerlendirme amacıyla kullanılmalıdır. Anahtar dizini ve dosya izinleri yapılandırmadan sonra kilitlenir; yerel ana anahtarın değiştirilmesi veya döndürülmesi desteklenmez."
 }

--- a/i18n/locales/tr-TR.json
+++ b/i18n/locales/tr-TR.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "Unable to cancel transition job",
   "Unable to load transition job": "Unable to load transition job",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS yalnızca değerlendirme amacıyla kullanılmalıdır. Sunucu tarafından yönetilen bir ana anahtar olmadan oluşturulan anahtarlar düz metin geliştirme modunda saklanır. Bu arka ucu üretim verileri için kullanmayın.",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS yalnızca değerlendirme amacıyla kullanılmalıdır. Anahtar dizini ve dosya izinleri yapılandırmadan sonra kilitlenir; yerel ana anahtarın değiştirilmesi veya döndürülmesi desteklenmez."
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS yalnızca değerlendirme amacıyla kullanılmalıdır. Anahtar dizini ve dosya izinleri yapılandırmadan sonra kilitlenir; yerel ana anahtarın değiştirilmesi veya döndürülmesi desteklenmez.",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/vi-VN.json
+++ b/i18n/locales/vi-VN.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "Unable to cancel transition job",
   "Unable to load transition job": "Unable to load transition job",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS chỉ dành cho mục đích đánh giá. Các khóa được tạo mà không có khóa chính do máy chủ quản lý sẽ được lưu ở dạng văn bản thuần trong chế độ phát triển. Không sử dụng backend này cho dữ liệu sản xuất.",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS chỉ dành cho mục đích đánh giá. Thư mục khóa và quyền tệp sẽ bị khóa sau khi cấu hình; việc thay đổi hoặc xoay vòng khóa chính cục bộ không được hỗ trợ."
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS chỉ dành cho mục đích đánh giá. Thư mục khóa và quyền tệp sẽ bị khóa sau khi cấu hình; việc thay đổi hoặc xoay vòng khóa chính cục bộ không được hỗ trợ.",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/vi-VN.json
+++ b/i18n/locales/vi-VN.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "Transition job started",
   "Transitioned": "Transitioned",
   "Unable to cancel transition job": "Unable to cancel transition job",
-  "Unable to load transition job": "Unable to load transition job"
+  "Unable to load transition job": "Unable to load transition job",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS chỉ dành cho mục đích đánh giá. Các khóa được tạo mà không có khóa chính do máy chủ quản lý sẽ được lưu ở dạng văn bản thuần trong chế độ phát triển. Không sử dụng backend này cho dữ liệu sản xuất.",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS chỉ dành cho mục đích đánh giá. Thư mục khóa và quyền tệp sẽ bị khóa sau khi cấu hình; việc thay đổi hoặc xoay vòng khóa chính cục bộ không được hỗ trợ."
 }

--- a/i18n/locales/zh-CN.json
+++ b/i18n/locales/zh-CN.json
@@ -1594,5 +1594,12 @@
   "Unable to cancel transition job": "无法取消迁移任务",
   "Unable to load transition job": "无法加载迁移任务",
   "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS 仅用于体验。未由服务端主密钥保护的密钥会以明文开发模式存储，请勿将此后端用于生产数据。",
-  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS 仅用于体验。配置后密钥目录和文件权限将被锁定；当前不支持更改或轮换本地主密钥。"
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS 仅用于体验。配置后密钥目录和文件权限将被锁定；当前不支持更改或轮换本地主密钥。",
+  "KMS configuration changed": "KMS configuration changed",
+  "KMS configuration changed on the server. Reset the form to the current status before saving.": "KMS configuration changed on the server. Reset the form to the current status before saving.",
+  "Unsupported KMS backend": "Unsupported KMS backend",
+  "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.": "This KMS backend is not supported by this Console version. Upgrade Console before reconfiguring KMS.",
+  "Console cannot safely edit a newer or unknown KMS backend type.": "Console cannot safely edit a newer or unknown KMS backend type.",
+  "Local KMS key files must use owner-only permissions such as 384 for 0o600.": "Local KMS key files must use owner-only permissions such as 384 for 0o600.",
+  "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration.": "Key created but could not update the default SSE key. The new key ID has been placed in the default key field so you can retry saving the configuration."
 }

--- a/i18n/locales/zh-CN.json
+++ b/i18n/locales/zh-CN.json
@@ -1592,5 +1592,7 @@
   "Transition job started": "迁移任务已启动",
   "Transitioned": "已迁移",
   "Unable to cancel transition job": "无法取消迁移任务",
-  "Unable to load transition job": "无法加载迁移任务"
+  "Unable to load transition job": "无法加载迁移任务",
+  "Local KMS is intended for evaluation only. Keys created without a server-managed master key are stored using plaintext development mode. Do not use this backend for production data.": "Local KMS 仅用于体验。未由服务端主密钥保护的密钥会以明文开发模式存储，请勿将此后端用于生产数据。",
+  "Local KMS is intended for evaluation only. The key directory and file permissions are locked after configuration; changing or rotating the local master key is not supported.": "Local KMS 仅用于体验。配置后密钥目录和文件权限将被锁定；当前不支持更改或轮换本地主密钥。"
 }

--- a/lib/sse/config.ts
+++ b/lib/sse/config.ts
@@ -1,0 +1,111 @@
+import type { KmsServiceStatusResponse } from "@/types/kms"
+
+export type ConfigFormBackendType = "local" | "vault-kv2" | "vault-transit" | "static" | "unsupported"
+
+export type ConfigFormState = {
+  backendType: ConfigFormBackendType
+  keyDir: string
+  filePermissions: string
+  defaultKeyId: string
+  timeoutSeconds: string
+  retryAttempts: string
+  enableCache: boolean
+  maxCachedKeys: string
+  cacheTtlSeconds: string
+  address: string
+  vaultToken: string
+  namespace: string
+  mountPath: string
+  kvMount: string
+  keyPathPrefix: string
+  skipTlsVerify: boolean
+  secretKey: string
+  staticKeyId: string
+}
+
+export const INITIAL_FORM_STATE: ConfigFormState = {
+  backendType: "vault-transit",
+  keyDir: "",
+  filePermissions: "384",
+  defaultKeyId: "",
+  timeoutSeconds: "30",
+  retryAttempts: "3",
+  enableCache: true,
+  maxCachedKeys: "1000",
+  cacheTtlSeconds: "3600",
+  address: "",
+  vaultToken: "",
+  namespace: "",
+  mountPath: "transit",
+  kvMount: "secret",
+  keyPathPrefix: "rustfs/kms/keys",
+  skipTlsVerify: false,
+  secretKey: "",
+  staticKeyId: "",
+}
+
+export function normalizeBackendType(value?: string | null): ConfigFormBackendType | null {
+  switch (value) {
+    case null:
+    case undefined:
+      return null
+    case "Local":
+      return "local"
+    case "Vault":
+    case "VaultKV2":
+      return "vault-kv2"
+    case "VaultTransit":
+      return "vault-transit"
+    case "Static":
+      return "static"
+    default:
+      return "unsupported"
+  }
+}
+
+export function buildFormStateFromStatus(status: KmsServiceStatusResponse | null): ConfigFormState {
+  if (!status) return INITIAL_FORM_STATE
+
+  const summary = status.config_summary
+  const backendSummary = summary?.backend_summary
+  const cacheSummary = summary?.cache_summary
+  const backendType =
+    normalizeBackendType(status.backend_type ?? summary?.backend_type) ?? INITIAL_FORM_STATE.backendType
+
+  return {
+    backendType,
+    keyDir: backendSummary?.key_dir ?? "",
+    filePermissions: String(backendSummary?.file_permissions ?? 384),
+    defaultKeyId: summary?.default_key_id ?? "",
+    timeoutSeconds: String(summary?.timeout_seconds ?? 30),
+    retryAttempts: String(summary?.retry_attempts ?? 3),
+    enableCache: summary?.enable_cache ?? cacheSummary?.enabled ?? true,
+    maxCachedKeys: String(summary?.max_cached_keys ?? cacheSummary?.max_keys ?? 1000),
+    cacheTtlSeconds: String(summary?.cache_ttl_seconds ?? cacheSummary?.ttl_seconds ?? 3600),
+    address: backendSummary?.address ?? "",
+    vaultToken: "",
+    namespace: backendSummary?.namespace ?? "",
+    mountPath: backendSummary?.mount_path ?? "transit",
+    kvMount: backendSummary?.kv_mount ?? "secret",
+    keyPathPrefix: backendSummary?.key_path_prefix ?? "rustfs/kms/keys",
+    secretKey: "",
+    staticKeyId: backendSummary?.key_id ?? "",
+    skipTlsVerify: backendSummary?.skip_tls_verify ?? false,
+  }
+}
+
+export function getFormSyncDecision(
+  currentFormState: ConfigFormState,
+  baselineFormState: ConfigFormState,
+  nextBaselineFormState: ConfigFormState,
+): "sync" | "conflict" | "keep-dirty" {
+  const currentJson = JSON.stringify(currentFormState)
+  const baselineJson = JSON.stringify(baselineFormState)
+  if (currentJson === baselineJson) return "sync"
+  if (baselineJson !== JSON.stringify(nextBaselineFormState)) return "conflict"
+  return "keep-dirty"
+}
+
+export function isSafeLocalFilePermissions(mode: number) {
+  return Number.isInteger(mode) && mode >= 0 && mode <= 0o777 && (mode & 0o077) === 0
+}

--- a/tests/lib/sse-config.test.ts
+++ b/tests/lib/sse-config.test.ts
@@ -1,0 +1,87 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+
+import {
+  INITIAL_FORM_STATE,
+  buildFormStateFromStatus,
+  getFormSyncDecision,
+  isSafeLocalFilePermissions,
+  normalizeBackendType,
+  type ConfigFormState,
+} from "../../lib/sse/config"
+import type { KmsServiceStatusResponse } from "../../types/kms"
+
+function statusWithBackend(backendType: string | null): KmsServiceStatusResponse {
+  return {
+    status: backendType ? "Configured" : "NotConfigured",
+    backend_type: backendType as KmsServiceStatusResponse["backend_type"],
+    healthy: backendType ? true : null,
+    config_summary: backendType
+      ? {
+          backend_type: backendType as NonNullable<KmsServiceStatusResponse["config_summary"]>["backend_type"],
+          default_key_id: "server-default",
+          backend_summary: {
+            address: "http://vault.example.test:8200",
+            mount_path: "transit",
+          },
+        }
+      : null,
+  }
+}
+
+test("normalizeBackendType keeps absent KMS configuration unselected and fails closed for future backends", () => {
+  assert.equal(normalizeBackendType(null), null)
+  assert.equal(normalizeBackendType(undefined), null)
+  assert.equal(normalizeBackendType("Local"), "local")
+  assert.equal(normalizeBackendType("VaultKV2"), "vault-kv2")
+  assert.equal(normalizeBackendType("VaultTransit"), "vault-transit")
+  assert.equal(normalizeBackendType("Static"), "static")
+  assert.equal(normalizeBackendType("FutureBackend"), "unsupported")
+})
+
+test("buildFormStateFromStatus does not coerce NotConfigured or future backends to writable Local", () => {
+  assert.deepEqual(buildFormStateFromStatus(statusWithBackend(null)), INITIAL_FORM_STATE)
+  assert.equal(buildFormStateFromStatus(statusWithBackend("FutureBackend")).backendType, "unsupported")
+})
+
+test("getFormSyncDecision refreshes clean forms when the server baseline changes", () => {
+  const nextBaseline = {
+    ...INITIAL_FORM_STATE,
+    backendType: "local",
+    keyDir: "/var/lib/rustfs/kms",
+  } satisfies ConfigFormState
+
+  assert.equal(getFormSyncDecision(INITIAL_FORM_STATE, INITIAL_FORM_STATE, nextBaseline), "sync")
+})
+
+test("getFormSyncDecision blocks silent overwrite when local edits race server changes", () => {
+  const dirtyForm = {
+    ...INITIAL_FORM_STATE,
+    defaultKeyId: "local-edit",
+  } satisfies ConfigFormState
+  const changedServerBaseline = {
+    ...INITIAL_FORM_STATE,
+    defaultKeyId: "server-edit",
+  } satisfies ConfigFormState
+
+  assert.equal(getFormSyncDecision(dirtyForm, INITIAL_FORM_STATE, changedServerBaseline), "conflict")
+})
+
+test("getFormSyncDecision preserves dirty edits when the server baseline is unchanged", () => {
+  const dirtyForm = {
+    ...INITIAL_FORM_STATE,
+    defaultKeyId: "local-edit",
+  } satisfies ConfigFormState
+
+  assert.equal(getFormSyncDecision(dirtyForm, INITIAL_FORM_STATE, INITIAL_FORM_STATE), "keep-dirty")
+})
+
+test("isSafeLocalFilePermissions accepts owner-only modes and rejects exposed or special modes", () => {
+  assert.equal(isSafeLocalFilePermissions(0o600), true)
+  assert.equal(isSafeLocalFilePermissions(0o700), true)
+  assert.equal(isSafeLocalFilePermissions(0o666), false)
+  assert.equal(isSafeLocalFilePermissions(0o777), false)
+  assert.equal(isSafeLocalFilePermissions(0o4755), false)
+  assert.equal(isSafeLocalFilePermissions(-1), false)
+  assert.equal(isSafeLocalFilePermissions(0.5), false)
+})

--- a/tests/lib/sse-safety.test.js
+++ b/tests/lib/sse-safety.test.js
@@ -27,7 +27,8 @@ test("SSE mutations use one synchronous lock and block unresolved configuration 
   assert.match(source, /beginMutation/)
   assert.match(source, /if \(statusError \|\| loadingStatus\)/)
   assert.match(source, /const mutationLocked = Boolean\(activeMutation \|\| statusError \|\| loadingStatus\)/)
-  assert.match(source, /const formDisabled = mutationLocked \|\| loadingStatus \|\| submittingConfig/)
+  assert.match(source, /const formDisabled =\s+mutationLocked/)
+  assert.match(source, /Boolean\(configBaselineConflict\)/)
   assert.match(source, /disabled=\{formDisabled\}/)
 })
 
@@ -43,18 +44,20 @@ test("default key protection rechecks current status before destructive actions"
 
 test("default-key creation uses a safe status baseline and clears secrets after status sync", () => {
   assert.match(source, /submitConfiguration\(createdKeyId, "defaultKey", buildFormStateFromStatus\(status\)\)/)
-  assert.match(source, /const nextFormState = buildFormStateFromStatus\(res\)/)
+  assert.match(source, /const nextFormState = buildFormStateFromStatus\(nextStatus\)/)
   assert.match(source, /setFormState\(nextFormState\)/)
   assert.match(source, /setFormState\(\(current\) => \(\{ \.\.\.current, vaultToken: "" \}\)\)/)
   assert.doesNotMatch(source, /if \(current\.vaultToken && next\.backendType !== "local"\)/)
 })
 
 test("Local KMS remains evaluation-only while safe fields can be reconfigured", () => {
-  assert.match(source, /backendType: "vault-transit"/)
+  assert.match(source, /INITIAL_FORM_STATE/)
   assert.match(source, /const localKmsConfigured = hasConfiguration && status\?\.backend_type === "Local"/)
   assert.match(source, /backend_type: "Local"/)
   assert.match(source, /allow_insecure_dev_defaults: !hasStoredLocalMasterKey/)
   assert.match(source, /localKmsConfigured && !hasStoredLocalFilePermissions \? undefined/)
+  assert.match(source, /isSafeLocalFilePermissions\(filePermissions\)/)
+  assert.match(source, /Local KMS key files must use owner-only permissions such as 384 for 0o600\./)
   assert.match(source, /disabled=\{formDisabled \|\| localKmsConfigured\}/)
   assert.match(
     source,
@@ -64,6 +67,22 @@ test("Local KMS remains evaluation-only while safe fields can be reconfigured", 
   assert.doesNotMatch(source, /const localKmsReadOnly/)
   assert.doesNotMatch(source, /master_key: values\./)
   assert.doesNotMatch(source, /id="localMasterKey"/)
+})
+
+test("created default-key recovery keeps the key id visible after reconfigure failure", () => {
+  assert.match(source, /const recoveryMessage = t\(/)
+  assert.match(source, /setFormState\(\(current\) => \(\{ \.\.\.current, defaultKeyId: createdKeyId \}\)\)/)
+  assert.match(source, /setConfigFormErrorField\("defaultKeyId"\)/)
+  assert.match(source, /The new key ID has been placed in the default key field/)
+})
+
+test("unsupported KMS backends fail closed and require a current baseline before saving", () => {
+  assert.match(source, /formState\.backendType === "unsupported"/)
+  assert.match(source, /<SelectItem value="unsupported" disabled>/)
+  assert.match(source, /This KMS backend is not supported by this Console version/)
+  assert.match(source, /getFormSyncDecision/)
+  assert.match(source, /KMS configuration changed on the server\. Reset the form to the current status before saving\./)
+  assert.match(source, /setConfigBaselineConflict\(null\)/)
 })
 
 test("SSE form and dialogs stay reachable on narrow screens", () => {

--- a/tests/lib/sse-safety.test.js
+++ b/tests/lib/sse-safety.test.js
@@ -18,7 +18,7 @@ test("SSE status and key reads fail closed with persistent recovery states", () 
   assert.match(source, /statusError \|\| keysError \|\| loadingKeys \|\| loadingStatus/)
   assert.match(
     source,
-    /disabled=\{Boolean\(activeMutation\) \|\| loadingKeys \|\| loadingStatus \|\| Boolean\(keysError\)/,
+    /disabled=\{\s*Boolean\(activeMutation\) \|\|\s*loadingKeys \|\|\s*loadingStatus \|\|\s*Boolean\(keysError\)/,
   )
 })
 
@@ -49,14 +49,19 @@ test("default-key creation uses a safe status baseline and clears secrets after 
   assert.doesNotMatch(source, /if \(current\.vaultToken && next\.backendType !== "local"\)/)
 })
 
-test("Local KMS cannot be reconfigured until the backend supports safe secret rotation", () => {
+test("Local KMS remains evaluation-only while safe fields can be reconfigured", () => {
   assert.match(source, /backendType: "vault-transit"/)
-  assert.match(source, /const localKmsReadOnly = hasConfiguration && formState\.backendType === "local"/)
+  assert.match(source, /const localKmsConfigured = hasConfiguration && status\?\.backend_type === "Local"/)
+  assert.match(source, /backend_type: "Local"/)
+  assert.match(source, /allow_insecure_dev_defaults: !hasStoredLocalMasterKey/)
+  assert.match(source, /localKmsConfigured && !hasStoredLocalFilePermissions \? undefined/)
+  assert.match(source, /disabled=\{formDisabled \|\| localKmsConfigured\}/)
   assert.match(
     source,
-    /Local filesystem KMS configuration is read-only in Console until safe master-key rotation is available\./,
+    /Local KMS is intended for evaluation only\. Keys created without a server-managed master key are stored using plaintext development mode\. Do not use this backend for production data\./,
   )
-  assert.match(source, /<SelectItem value="local" disabled>/)
+  assert.match(source, /<SelectItem value="local">/)
+  assert.doesNotMatch(source, /const localKmsReadOnly/)
   assert.doesNotMatch(source, /master_key: values\./)
   assert.doesNotMatch(source, /id="localMasterKey"/)
 })

--- a/types/kms.ts
+++ b/types/kms.ts
@@ -58,6 +58,7 @@ export interface KmsLocalConfigPayload {
   backend_type: "Local"
   key_dir: string
   file_permissions?: number
+  allow_insecure_dev_defaults?: boolean
   default_key_id?: string
   timeout_seconds?: number
   retry_attempts?: number


### PR DESCRIPTION
# Pull Request

## Description

Enable Local KMS configuration and safe day-to-day key management in Console for evaluation environments. The UI explicitly warns that Local KMS is not for production, opts into plaintext development mode only when no server-managed local master key exists, and locks fields that cannot be changed safely after initial configuration.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [x] Security fix

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed

```bash
node scripts/apply-theme-overrides.js
tsc --noEmit
eslint "app/(dashboard)/sse/page.tsx" types/kms.ts tests/lib/sse-safety.test.js
node --experimental-strip-types --import ./scripts/register-typescript-loader.mjs --test tests/lib/*.test.{js,ts}
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

Related to rustfs/rustfs#5063.

## Screenshots (if applicable)

N/A.

## Additional Notes

Local KMS remains explicitly evaluation-only. After initial configuration, Console prevents changing the backend, key directory, and file permissions. It does not send local master-key material during updates. Default-key, cache, and timeout settings remain editable, and key creation can safely set the new key as the default.