### PR TITLE
fix(auth): resolve OIDC logout URL before clearing auth state

### DIFF
--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -137,16 +137,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logoutWithOidcRedirect = useCallback(async () => {
     const oidcSession = isValidOidcLogoutSession(oidcSessionStore) ? oidcSessionStore : undefined
-    logout()
 
-    if (!oidcSession) return false
+    if (!oidcSession) {
+      logout()
+      return false
+    }
 
     try {
+      // Build the URL before logout(), or DashboardAuthGuard redirects to login before this navigation runs.
       const { configManager } = await import("@/lib/config")
       const config = await configManager.loadConfig()
-      window.location.href = buildOidcLogoutUrl(config.serverHost, oidcSession.logoutToken)
+      const logoutUrl = buildOidcLogoutUrl(config.serverHost, oidcSession.logoutToken)
+
+      logout()
+      window.location.href = logoutUrl
       return true
     } catch {
+      logout()
       return false
     }
   }, [oidcSessionStore, logout])

--- a/tests/lib/oidc-logout-source.test.js
+++ b/tests/lib/oidc-logout-source.test.js
@@ -1,0 +1,16 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+
+const source = fs.readFileSync("contexts/auth-context.tsx", "utf8")
+
+test("OIDC federated logout builds its destination before clearing auth state", () => {
+  assert.match(
+    source,
+    /const logoutUrl = buildOidcLogoutUrl\(config\.serverHost, oidcSession\.logoutToken\)\s*\n\s*logout\(\)\s*\n\s*window\.location\.href = logoutUrl/,
+  )
+})
+
+test("OIDC federated logout does not clear auth state before awaiting config", () => {
+  assert.doesNotMatch(source, /logout\(\)\s*\n\s*if \(!oidcSession\) return false/)
+})


### PR DESCRIPTION
## Description

`logoutWithOidcRedirect()` called `logout()` before awaiting the config load, then set `window.location.href` to the RP-logout endpoint. Clearing auth state flips `isAuthenticated` to `false`, so during the `await import()` / `loadConfig()` gap `DashboardAuthGuard` fires `router.replace("/auth/login/?unauthorized=true")`. That redirect preempts the not-yet-assigned `window.location.href`, so the browser never reaches `/rustfs/admin/v3/oidc/logout`, the one-time logout token is never consumed, and the IdP session is left active.

This resolves the logout URL first and only then clears state and navigates, in the same synchronous step, so nothing can `await` between the state change and the redirect. Behaviour is otherwise unchanged: local state is still always cleared, and the no-session / error paths still return `false`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

Added `tests/lib/oidc-logout-source.test.js` to lock the ordering (destination built before `logout()`; state not cleared ahead of the config await). Reproduced the original race and verified the fix against Authentik as the IdP: logout now reaches `/rustfs/admin/v3/oidc/logout`, which redirects to the provider `end_session_endpoint` and terminates the session.

```bash
pnpm test:run
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

Closes #190
