### PR TITLE
fix(status): honor active first scanner cycle

### DIFF
--- a/app/(dashboard)/status/page.tsx
+++ b/app/(dashboard)/status/page.tsx
@@ -6,7 +6,12 @@ import { Button } from "@/components/ui/button"
 import { Spinner } from "@/components/ui/spinner"
 import { usePerformanceData, type PerformanceDataSource } from "@/hooks/use-performance-data"
 import { usePermissions } from "@/hooks/use-permissions"
-import { buildRunningStatusView, formatRelativeTime, resolveUsageFreshness } from "@/lib/performance-data"
+import {
+  buildRunningStatusView,
+  formatRelativeTime,
+  isScannerCycleActive,
+  resolveUsageFreshness,
+} from "@/lib/performance-data"
 import { cn } from "@/lib/utils"
 import {
   RiArchiveDrawerFill,
@@ -97,10 +102,9 @@ export default function PerformancePage() {
   )
 
   const scannerStartedAt = metricsInfo.aggregated?.scanner?.current_started
-  const scannerCycle = metricsInfo.aggregated?.scanner?.current_cycle
   const scannerCompleteTimes = metricsInfo.aggregated?.scanner?.cycle_complete_times ?? []
   const scannerCompletedAt = scannerCompleteTimes.at(-1)
-  const scannerActive = (scannerCycle ?? 0) > 0
+  const scannerActive = isScannerCycleActive(metricsInfo)
   const scannerStatus = scannerActive ? t("Scanning") : scannerCompletedAt ? t("Idle") : t("Never run")
   const scannerDuration = useMemo(() => {
     if (!scannerStartedAt) return undefined

--- a/lib/performance-data.ts
+++ b/lib/performance-data.ts
@@ -111,6 +111,7 @@ export interface MetricsInfo {
   aggregated?: {
     scanner?: {
       current_cycle?: number
+      current_cycle_active?: boolean
       current_started?: string
       cycle_complete_times?: string[]
     }
@@ -630,6 +631,7 @@ export function normalizeMetricsInfo(value: unknown): MetricsInfo {
   const aggregated = asRecord(source.aggregated ?? source.Aggregated)
   const scanner = asRecord(aggregated.scanner ?? aggregated.Scanner)
   const currentCycle = asNonNegativeNumber(scanner.current_cycle ?? scanner.currentCycle)
+  const currentCycleActive = asBoolean(scanner.current_cycle_active ?? scanner.currentCycleActive)
   const currentStarted = asTimestamp(scanner.current_started ?? scanner.currentStarted)
   const cycleCompleteTimes = asArray<unknown>(scanner.cycle_complete_times ?? scanner.cycleCompleteTimes).flatMap(
     (item) => {
@@ -638,17 +640,25 @@ export function normalizeMetricsInfo(value: unknown): MetricsInfo {
     },
   )
 
-  if (currentCycle === undefined && !currentStarted && !cycleCompleteTimes.length) return {}
+  if (currentCycle === undefined && currentCycleActive === undefined && !currentStarted && !cycleCompleteTimes.length) {
+    return {}
+  }
 
   return {
     aggregated: {
       scanner: {
         ...(currentCycle !== undefined ? { current_cycle: currentCycle } : {}),
+        ...(currentCycleActive !== undefined ? { current_cycle_active: currentCycleActive } : {}),
         ...(currentStarted ? { current_started: currentStarted } : {}),
         ...(cycleCompleteTimes.length ? { cycle_complete_times: cycleCompleteTimes } : {}),
       },
     },
   }
+}
+
+export function isScannerCycleActive(metricsInfo: MetricsInfo): boolean {
+  const scanner = metricsInfo.aggregated?.scanner
+  return scanner?.current_cycle_active ?? (scanner?.current_cycle ?? 0) > 0
 }
 
 export function summarizeServerStates(

--- a/tests/lib/performance-data.test.js
+++ b/tests/lib/performance-data.test.js
@@ -4,6 +4,7 @@ import assert from "node:assert/strict"
 import {
   buildRunningStatusView,
   formatRelativeTime,
+  isScannerCycleActive,
   normalizeClusterDiagnostics,
   normalizeDataUsageInfo,
   normalizeMetricsInfo,
@@ -246,15 +247,31 @@ test("normalizeMetricsInfo rejects missing and invalid scanner timestamps", () =
   )
 })
 
-test("normalizeMetricsInfo keeps the scanner cycle state for active and idle displays", () => {
-  assert.equal(
-    normalizeMetricsInfo({ aggregated: { scanner: { current_cycle: 3 } } }).aggregated?.scanner?.current_cycle,
-    3,
-  )
-  assert.equal(
-    normalizeMetricsInfo({ aggregated: { scanner: { current_cycle: 0 } } }).aggregated?.scanner?.current_cycle,
-    0,
-  )
+test("normalizeMetricsInfo keeps explicit scanner activity and legacy cycle fallback", () => {
+  const activeFirstCycle = normalizeMetricsInfo({
+    aggregated: { scanner: { current_cycle: 0, current_cycle_active: true } },
+  })
+  assert.equal(activeFirstCycle.aggregated?.scanner?.current_cycle, 0)
+  assert.equal(activeFirstCycle.aggregated?.scanner?.current_cycle_active, true)
+  assert.equal(isScannerCycleActive(activeFirstCycle), true)
+
+  const explicitIdle = normalizeMetricsInfo({
+    aggregated: { scanner: { current_cycle: 3, current_cycle_active: false } },
+  })
+  assert.equal(explicitIdle.aggregated?.scanner?.current_cycle_active, false)
+  assert.equal(isScannerCycleActive(explicitIdle), false)
+
+  const activityOnly = normalizeMetricsInfo({ aggregated: { scanner: { current_cycle_active: false } } })
+  assert.equal(activityOnly.aggregated?.scanner?.current_cycle_active, false)
+
+  const camelCaseActivity = normalizeMetricsInfo({
+    aggregated: { scanner: { currentCycle: 0, currentCycleActive: true } },
+  })
+  assert.equal(camelCaseActivity.aggregated?.scanner?.current_cycle_active, true)
+  assert.equal(isScannerCycleActive(camelCaseActivity), true)
+
+  assert.equal(isScannerCycleActive(normalizeMetricsInfo({ aggregated: { scanner: { current_cycle: 3 } } })), true)
+  assert.equal(isScannerCycleActive(normalizeMetricsInfo({ aggregated: { scanner: { current_cycle: 0 } } })), false)
 })
 
 test("formatRelativeTime follows the active locale and advances with the clock", () => {

--- a/tests/lib/performance-status-source.test.js
+++ b/tests/lib/performance-status-source.test.js
@@ -11,6 +11,7 @@ test("status page passes every normalized admin info state into infrastructure h
   assert.match(source, /initializingServers=\{serverSummary\?\.initializing\}/)
   assert.match(source, /unknownDisks=\{systemInfo\.backend\?\.unknownDisks\}/)
   assert.match(source, /topology=\{runningStatus\.topology\}/)
+  assert.match(source, /isScannerCycleActive\(metricsInfo\)/)
   assert.doesNotMatch(source, /unknownDisks=.*\?\? 0/)
 })
 

--- a/tests/lib/running-status-safety.test.js
+++ b/tests/lib/running-status-safety.test.js
@@ -56,7 +56,7 @@ test("running status distinguishes unknown values and exposes recovery feedback"
   assert.match(pageSource, /lastUpdatedAt/)
   assert.match(pageSource, /sourceErrors/)
   assert.match(pageSource, /order-2 xl:order-3 xl:col-span-2/)
-  assert.match(pageSource, /scannerCycle/)
+  assert.match(pageSource, /isScannerCycleActive\(metricsInfo\)/)
   assert.match(pageSource, /t\("Scanner Status"\)/)
   assert.doesNotMatch(pageSource, /dayjs\(last\)/)
   assert.doesNotMatch(pageSource, /t\("Uptime"\)/)


### PR DESCRIPTION
# Pull Request

## Description

RustFS reports `current_cycle_active` separately because scanner cycle ID `0` is a valid active first cycle. The Running Status page previously inferred activity only from `current_cycle > 0`, so an active first cycle was displayed as `Never run`.

This change preserves the explicit activity field during metrics normalization and treats it as authoritative. When the field is absent, the Console retains the legacy nonzero-cycle fallback for compatibility with older RustFS nodes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed

```bash
pnpm install --frozen-lockfile
pnpm test:run
pnpm type-check
pnpm lint
pnpm format:check
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

Related to rustfs/rustfs#5163.

## Screenshots (if applicable)

N/A. The change corrects the status derived from the existing metrics response without changing layout or styling.

## Additional Notes

The explicit field was added by rustfs/rustfs#5397. The fallback keeps the Console compatible with RustFS versions that do not yet emit it.
