### PR TITLE
feat(replication): gate console controls by capabilities

### DIFF
--- a/components/buckets/replication-tab.tsx
+++ b/components/buckets/replication-tab.tsx
@@ -10,6 +10,7 @@ import { DataTable } from "@/components/data-table/data-table"
 import { useDataTable } from "@/hooks/use-data-table"
 import { useBucket } from "@/hooks/use-bucket"
 import { usePermissions } from "@/hooks/use-permissions"
+import { useRuntimeCapabilities } from "@/hooks/use-runtime-capabilities"
 import { ReplicationNewForm } from "@/components/replication/new-form"
 import { useDialog } from "@/lib/feedback/dialog"
 import { useMessage } from "@/lib/feedback/message"
@@ -35,10 +36,19 @@ export function BucketReplicationTab({ bucketName, hideTitle = false, renderHead
   const message = useMessage()
   const dialog = useDialog()
   const { canCapability } = usePermissions()
+  const { capabilities, error: capabilitiesError } = useRuntimeCapabilities()
   const { getBucketReplication, putBucketReplication, deleteBucketReplication, deleteRemoteReplicationTarget } =
     useBucket()
   const replicationContext = React.useMemo(() => ({ bucket: bucketName }), [bucketName])
-  const canEditReplication = canCapability("bucket.replication.edit", replicationContext)
+  const replicationSupported = capabilities?.replication.bucketReplication.status.state === "supported"
+  const remoteTargetsSupported = capabilities?.replication.remoteTargets.status.state === "supported"
+  const replicationSupportMessage =
+    capabilities?.replication.bucketReplication.status.reason ??
+    capabilities?.replication.remoteTargets.status.reason ??
+    capabilitiesError ??
+    t("Unable to load replication rules. Refresh before making changes.")
+  const canEditReplication = canCapability("bucket.replication.edit", replicationContext) && replicationSupported
+  const canAddReplication = canEditReplication && remoteTargetsSupported
 
   const [data, setData] = React.useState<ReplicationRule[]>([])
   const [loading, setLoading] = React.useState(false)
@@ -195,18 +205,16 @@ export function BucketReplicationTab({ bucketName, hideTitle = false, renderHead
         enableSorting: false,
         cell: ({ row }) => (
           <div className="flex items-center gap-2">
-            {canEditReplication ? (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => confirmDelete(row.original)}
-                disabled={Boolean(loadError) || loading || mutatingRuleId !== null}
-                aria-label={`${t("Delete Rule")} ${row.original.ID ?? t("Unnamed rule")}`}
-              >
-                <RiDeleteBin7Line className="size-4" aria-hidden />
-                <span>{t("Delete")}</span>
-              </Button>
-            ) : null}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => confirmDelete(row.original)}
+              disabled={Boolean(loadError) || loading || mutatingRuleId !== null || !canEditReplication}
+              aria-label={`${t("Delete Rule")} ${row.original.ID ?? t("Unnamed rule")}`}
+            >
+              <RiDeleteBin7Line className="size-4" aria-hidden />
+              <span>{t("Delete")}</span>
+            </Button>
           </div>
         ),
       },
@@ -222,15 +230,13 @@ export function BucketReplicationTab({ bucketName, hideTitle = false, renderHead
 
   const actions = (
     <>
-      {canEditReplication ? (
-        <Button
-          onClick={() => setNewFormOpen(true)}
-          disabled={Boolean(loadError) || loading || mutatingRuleId !== null}
-        >
-          <RiAddLine className="size-4" aria-hidden />
-          <span>{t("Add Replication Rule")}</span>
-        </Button>
-      ) : null}
+      <Button
+        onClick={() => setNewFormOpen(true)}
+        disabled={Boolean(loadError) || loading || mutatingRuleId !== null || !canAddReplication}
+      >
+        <RiAddLine className="size-4" aria-hidden />
+        <span>{t("Add Replication Rule")}</span>
+      </Button>
       <Button variant="outline" onClick={loadData} disabled={loading || mutatingRuleId !== null}>
         <RiRefreshLine className="size-4" aria-hidden />
         <span>{t("Refresh")}</span>
@@ -253,6 +259,13 @@ export function BucketReplicationTab({ bucketName, hideTitle = false, renderHead
         <Alert variant="destructive">
           <AlertTitle>{t("Replication rules unavailable")}</AlertTitle>
           <AlertDescription>{loadError}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {(capabilitiesError && !capabilities) || (capabilities && (!replicationSupported || !remoteTargetsSupported)) ? (
+        <Alert variant="destructive">
+          <AlertTitle>{t("Replication rules unavailable")}</AlertTitle>
+          <AlertDescription>{replicationSupportMessage}</AlertDescription>
         </Alert>
       ) : null}
 

--- a/components/replication/new-form.tsx
+++ b/components/replication/new-form.tsx
@@ -12,10 +12,12 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Field, FieldContent, FieldError, FieldLabel } from "@/components/ui/field"
 import { useBucket } from "@/hooks/use-bucket"
+import { useRuntimeCapabilities } from "@/hooks/use-runtime-capabilities"
 import { useMessage } from "@/lib/feedback/message"
 import { getBytes, randomUUID } from "@/lib/functions"
 import { isMissingBucketConfiguration, normalizeReplicationRulesForRolelessConfig } from "@/lib/bucket-configuration"
 import { buildBucketReplicationTlsPayload, type BucketReplicationTlsMode } from "@/lib/bucket-replication-tls"
+import { getRuntimeCapabilityFieldState } from "@/lib/runtime-capabilities"
 
 interface ReplicationNewFormProps {
   open: boolean
@@ -36,7 +38,9 @@ interface ReplicationRulePayload extends Record<string, unknown> {
 export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }: ReplicationNewFormProps) {
   const { t } = useTranslation()
   const message = useMessage()
-  const { setRemoteReplicationTarget, putBucketReplication, getBucketReplication } = useBucket()
+  const { setRemoteReplicationTarget, listRemoteReplicationTargets, putBucketReplication, getBucketReplication } =
+    useBucket()
+  const { capabilities, isLoading: capabilitiesLoading, error: capabilitiesError } = useRuntimeCapabilities()
 
   const [level, setLevel] = useState("1")
   const [endpoint, setEndpoint] = useState("")
@@ -84,6 +88,77 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
     ],
     [],
   )
+
+  const canEditBucketField = useCallback(
+    (fieldName: string) => getRuntimeCapabilityFieldState(capabilities, "bucketReplication", fieldName) === "supported",
+    [capabilities],
+  )
+
+  const canEditTargetField = useCallback(
+    (fieldName: string) => getRuntimeCapabilityFieldState(capabilities, "remoteTargets", fieldName) === "supported",
+    [capabilities],
+  )
+
+  const canEditCurrentTagFilter =
+    tags.length > 1 ? canEditBucketField("Rule.Filter.And") : canEditBucketField("Rule.Filter.Tag")
+  const canAddTag = canEditBucketField("Rule.Filter.And")
+
+  const storageClassOptions = useMemo(() => {
+    const supported = capabilities?.storageClasses.supportedWriteClasses ?? []
+    const current = storageType.trim() || "STANDARD"
+    const values = [...supported]
+    if (!values.includes(current)) {
+      values.push(current)
+    }
+    return values
+  }, [capabilities, storageType])
+
+  const bucketHistoricalFields = useMemo(
+    () =>
+      (capabilities?.replication.bucketReplication.fields ?? []).filter(
+        (field) => field.state === "read_only_historical",
+      ),
+    [capabilities],
+  )
+
+  const remoteTargetUnsupportedFields = useMemo(
+    () => (capabilities?.replication.remoteTargets.fields ?? []).filter((field) => field.state === "unsupported"),
+    [capabilities],
+  )
+
+  const replicationFeaturesSupported =
+    capabilities?.replication.bucketReplication.status.state === "supported" &&
+    capabilities.replication.remoteTargets.status.state === "supported"
+  const requiredBucketFieldsSupported = [
+    "Role",
+    "Rule.ID",
+    "Rule.Status",
+    "Rule.Priority",
+    "Rule.Destination.Bucket",
+  ].every(canEditBucketField)
+  const requiredTargetFieldsSupported = [
+    "sourcebucket",
+    "endpoint",
+    "credentials.accessKey",
+    "credentials.secretKey",
+    "targetbucket",
+    "secure",
+    "path",
+    "api",
+    "type",
+    "region",
+    "bandwidth",
+    "replicationSync",
+    "skipTlsVerify",
+    "caCertPem",
+  ].every(canEditTargetField)
+  const controlsLocked =
+    submitting ||
+    capabilitiesLoading ||
+    !capabilities ||
+    !replicationFeaturesSupported ||
+    !requiredBucketFieldsSupported ||
+    !requiredTargetFieldsSupported
 
   const resetForm = useCallback(() => {
     setLevel("1")
@@ -163,7 +238,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
   }
 
   const handleSave = async () => {
-    if (submitting) return
+    if (submitting || controlsLocked) return
     if (!validate()) return
     if (!bucketName) {
       message.error(t("Bucket name is required"))
@@ -174,13 +249,18 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
     let remoteTargetSaved = false
     try {
       const tlsConfig = buildBucketReplicationTlsPayload(tls, tlsMode, caCertPem)
+      const currentTargets = (await listRemoteReplicationTargets(bucketName)) as Record<string, unknown>[]
+      const currentTarget = currentTargets.find((target) => {
+        const targetBucket = typeof target.targetbucket === "string" ? target.targetbucket : ""
+        const targetEndpoint = typeof target.endpoint === "string" ? target.endpoint : ""
+        return targetBucket === bucket || targetEndpoint === endpoint
+      })
       const config: Record<string, unknown> = {
         sourcebucket: bucketName,
         endpoint,
         credentials: {
           accessKey,
           secretKey,
-          expiration: "0001-01-01T00:00:00Z",
         },
         targetbucket: bucket,
         secure: tls,
@@ -191,21 +271,23 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
         api: "s3v4",
         type: "replication",
         replicationSync: modeType === "sync",
-        healthCheckDuration: Number(timecheck) || 60,
-        disableProxy: false,
-        resetBeforeDate: "0001-01-01T00:00:00Z",
-        totalDowntime: 0,
-        lastOnline: "0001-01-01T00:00:00Z",
-        isOnline: false,
-        latency: { curr: 0, avg: 0, max: 0 },
-        edge: false,
-        edgeSyncBeforeExpiry: false,
+        ...(canEditTargetField("healthCheckDuration") ? { healthCheckDuration: Number(timecheck) || 60 } : {}),
+        ...(canEditTargetField("disableProxy") ? { disableProxy: false } : {}),
+        ...(canEditTargetField("resetBeforeDate") ? { resetBeforeDate: "0001-01-01T00:00:00Z" } : {}),
+        ...(canEditTargetField("totalDowntime") ? { totalDowntime: 0 } : {}),
+        ...(canEditTargetField("lastOnline") ? { lastOnline: "0001-01-01T00:00:00Z" } : {}),
+        ...(canEditTargetField("isOnline") ? { isOnline: false } : {}),
+        ...(canEditTargetField("latency") ? { latency: { curr: 0, avg: 0, max: 0 } } : {}),
+        ...(canEditTargetField("edge") ? { edge: false } : {}),
+        ...(canEditTargetField("edgeSyncBeforeExpiry") ? { edgeSyncBeforeExpiry: false } : {}),
+        ...(typeof currentTarget?.arn === "string" && currentTarget.arn && canEditTargetField("arn")
+          ? { arn: currentTarget.arn }
+          : {}),
       }
 
       if (modeType === "async") {
         config.bandwidth = Number(getBytes(String(bandwidth), unit, true)) || 0
       }
-
       let oldConfig: {
         ReplicationConfiguration?: { Role?: string; Rules?: ReplicationRulePayload[] }
       } | null = null
@@ -226,42 +308,38 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
       remoteTargetSaved = true
 
       const newRule: ReplicationRulePayload = {
-        ID: randomUUID(),
-        Status: "Enabled",
-        Priority: parseInt(level) || 1,
-        SourceSelectionCriteria: {
-          SseKmsEncryptedObjects: { Status: "Enabled" },
-        },
-        ExistingObjectReplication: {
-          Status: existingObject ? "Enabled" : "Disabled",
-        },
-        DeleteMarkerReplication: {
-          Status: expiredDeleteMark ? "Enabled" : "Disabled",
-        },
-        DeleteReplication: {
-          Status: replicateDelete ? "Enabled" : "Disabled",
-        },
-        Destination: {
-          Bucket: targetResponse,
-          StorageClass: storageType || "STANDARD",
-        },
+        ...(canEditBucketField("Rule.ID") ? { ID: randomUUID() } : {}),
+        ...(canEditBucketField("Rule.Status") ? { Status: "Enabled" } : {}),
+        ...(canEditBucketField("Rule.Priority") ? { Priority: parseInt(level) || 1 } : {}),
+        ...(canEditBucketField("Rule.ExistingObjectReplication.Status")
+          ? { ExistingObjectReplication: { Status: existingObject ? "Enabled" : "Disabled" } }
+          : {}),
+        ...(canEditBucketField("Rule.DeleteMarkerReplication.Status")
+          ? { DeleteMarkerReplication: { Status: expiredDeleteMark ? "Enabled" : "Disabled" } }
+          : {}),
+        ...(canEditBucketField("Rule.DeleteReplication.Status")
+          ? { DeleteReplication: { Status: replicateDelete ? "Enabled" : "Disabled" } }
+          : {}),
+        ...(canEditBucketField("Rule.Destination.Bucket")
+          ? { Destination: { Bucket: targetResponse, StorageClass: storageType || "STANDARD" } }
+          : {}),
       }
 
       const validTags = tags.filter((tag) => tag.key && tag.value)
       const filter: Record<string, unknown> = {}
 
-      if (prefix) {
+      if (prefix && canEditBucketField("Rule.Filter.Prefix")) {
         filter.Prefix = prefix
       }
 
       if (validTags.length === 1) {
         const [singleTag] = validTags
-        if (singleTag) {
+        if (singleTag && canEditBucketField("Rule.Filter.Tag")) {
           filter.Tag = { Key: singleTag.key, Value: singleTag.value }
         }
-      } else if (validTags.length > 1) {
+      } else if (validTags.length > 1 && canEditBucketField("Rule.Filter.And")) {
         filter.And = {
-          ...(prefix ? { Prefix: prefix } : {}),
+          ...(prefix && canEditBucketField("Rule.Filter.Prefix") ? { Prefix: prefix } : {}),
           Tags: validTags.map((tag) => ({ Key: tag.key, Value: tag.value })),
         }
         delete filter.Prefix
@@ -352,6 +430,11 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                 {saveError}
               </div>
             ) : null}
+            {capabilitiesError ? (
+              <p role="alert" className="border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+                {capabilitiesError}
+              </p>
+            ) : null}
             <div className="space-y-4">
               <div className="grid gap-3 md:grid-cols-2">
                 <Field>
@@ -366,13 +449,18 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                       autoComplete="off"
                       value={level}
                       onChange={(e) => setLevel(e.target.value)}
+                      disabled={controlsLocked || !canEditBucketField("Rule.Priority")}
                     />
                   </FieldContent>
                 </Field>
                 <Field>
                   <FieldLabel>{t("Mode")}</FieldLabel>
                   <FieldContent>
-                    <Select value={modeType} onValueChange={(value) => setModeType(value ?? "")}>
+                    <Select
+                      value={modeType}
+                      onValueChange={(value) => setModeType(value ?? "")}
+                      disabled={controlsLocked || !canEditTargetField("replicationSync")}
+                    >
                       <SelectTrigger className="w-full" aria-label={t("Mode")}>
                         <SelectValue />
                       </SelectTrigger>
@@ -407,6 +495,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                         autoComplete="off"
                         placeholder={t("Please enter endpoint")}
                         spellCheck={false}
+                        disabled={controlsLocked || !canEditTargetField("endpoint")}
                       />
                     </div>
                   </FieldContent>
@@ -428,6 +517,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                       autoComplete="off"
                       placeholder={t("Please enter bucket")}
                       spellCheck={false}
+                      disabled={controlsLocked || !canEditTargetField("targetbucket")}
                     />
                   </FieldContent>
                   <FieldError id="replication-bucket-error">{fieldErrors.bucket}</FieldError>
@@ -448,6 +538,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                       placeholder={t("Please enter Access Key")}
                       autoComplete="off"
                       spellCheck={false}
+                      disabled={controlsLocked || !canEditTargetField("credentials.accessKey")}
                     />
                   </FieldContent>
                   <FieldError id="replication-access-key-error">{fieldErrors.accessKey}</FieldError>
@@ -469,6 +560,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                       placeholder={t("Please enter Secret Key")}
                       autoComplete="off"
                       spellCheck={false}
+                      disabled={controlsLocked || !canEditTargetField("credentials.secretKey")}
                     />
                   </FieldContent>
                   <FieldError id="replication-secret-key-error">{fieldErrors.secretKey}</FieldError>
@@ -484,21 +576,33 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                       autoComplete="off"
                       placeholder={t("Please enter region")}
                       spellCheck={false}
+                      disabled={controlsLocked || !canEditTargetField("region")}
                     />
                   </FieldContent>
                 </Field>
                 <Field>
                   <FieldLabel htmlFor="replication-storage-class">{t("Storage Class")}</FieldLabel>
                   <FieldContent>
-                    <Input
-                      id="replication-storage-class"
-                      name="replication-storage-class"
+                    <Select
                       value={storageType}
-                      onChange={(e) => setStorageType(e.target.value)}
-                      autoComplete="off"
-                      placeholder={t("Please enter storage class")}
-                      spellCheck={false}
-                    />
+                      onValueChange={(value) => setStorageType(value ?? "")}
+                      disabled={controlsLocked}
+                    >
+                      <SelectTrigger id="replication-storage-class" className="w-full" aria-label={t("Storage Class")}>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {storageClassOptions.map((option) => (
+                          <SelectItem
+                            key={option}
+                            value={option}
+                            disabled={!(capabilities?.storageClasses.supportedWriteClasses ?? []).includes(option)}
+                          >
+                            {option}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   </FieldContent>
                 </Field>
               </div>
@@ -514,6 +618,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                     autoComplete="off"
                     placeholder={t("Please enter prefix")}
                     spellCheck={false}
+                    disabled={controlsLocked || !canEditBucketField("Rule.Filter.Prefix")}
                   />
                 </FieldContent>
               </Field>
@@ -521,7 +626,13 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <FieldLabel className="text-sm font-medium">{t("Tags")}</FieldLabel>
-                  <Button type="button" variant="outline" size="sm" onClick={addTag} disabled={submitting}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={addTag}
+                    disabled={controlsLocked || !canAddTag}
+                  >
                     <RiAddLine className="size-4" aria-hidden />
                     {t("Add Tag")}
                   </Button>
@@ -539,6 +650,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                           autoComplete="off"
                           placeholder={t("Tag Name")}
                           spellCheck={false}
+                          disabled={controlsLocked || !canEditCurrentTagFilter}
                         />
                         <div className="flex items-center gap-2">
                           <Input
@@ -551,6 +663,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                             placeholder={t("Tag Value")}
                             className="flex-1"
                             spellCheck={false}
+                            disabled={controlsLocked || !canEditCurrentTagFilter}
                           />
                           <Button
                             type="button"
@@ -558,7 +671,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                             size="sm"
                             className="text-destructive"
                             aria-label={`${t("Delete")} ${t("Tag Name")} ${index + 1}`}
-                            disabled={tags.length === 1 || submitting}
+                            disabled={tags.length === 1 || controlsLocked || !canEditCurrentTagFilter}
                             onClick={() => removeTag(index)}
                           >
                             <RiDeleteBinLine className="size-4" aria-hidden />
@@ -585,7 +698,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                   id="replication-use-tls"
                   name="replication-use-tls"
                   checked={tls}
-                  disabled={submitting}
+                  disabled={controlsLocked || !canEditTargetField("secure")}
                   onCheckedChange={(checked) => {
                     setTls(checked)
                     if (!checked) {
@@ -608,7 +721,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                           if (value) setTlsMode(value as BucketReplicationTlsMode)
                           setFieldErrors((current) => ({ ...current, caCertPem: undefined }))
                         }}
-                        disabled={submitting}
+                        disabled={controlsLocked || !canEditTargetField("skipTlsVerify")}
                       >
                         <SelectTrigger id="replication-tls-verification" className="w-full">
                           <SelectValue />
@@ -644,7 +757,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                           }
                           className="min-h-32 font-mono"
                           placeholder="-----BEGIN CERTIFICATE-----"
-                          disabled={submitting}
+                          disabled={controlsLocked || !canEditTargetField("caCertPem")}
                           spellCheck={false}
                         />
                       </FieldContent>
@@ -680,6 +793,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                   name="replication-existing-object"
                   checked={existingObject}
                   onCheckedChange={setExistingObject}
+                  disabled={controlsLocked || !canEditBucketField("Rule.ExistingObjectReplication.Status")}
                 />
               </div>
 
@@ -695,6 +809,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                   name="replication-expired-delete-marker"
                   checked={expiredDeleteMark}
                   onCheckedChange={setExpiredDeleteMark}
+                  disabled={controlsLocked || !canEditBucketField("Rule.DeleteMarkerReplication.Status")}
                 />
               </div>
 
@@ -710,6 +825,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                   name="replication-delete"
                   checked={replicateDelete}
                   onCheckedChange={setReplicateDelete}
+                  disabled={controlsLocked || !canEditBucketField("Rule.DeleteReplication.Status")}
                 />
               </div>
 
@@ -735,6 +851,7 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                         aria-invalid={Boolean(fieldErrors.timecheck)}
                         aria-describedby={fieldErrors.timecheck ? "replication-health-check-interval-error" : undefined}
                         className="w-32"
+                        disabled={controlsLocked || !canEditTargetField("healthCheckDuration")}
                       />
                     </FieldContent>
                     <FieldError id="replication-health-check-interval-error">{fieldErrors.timecheck}</FieldError>
@@ -753,8 +870,13 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                           value={bandwidth}
                           onChange={(e) => setBandwidth(Number(e.target.value))}
                           className="w-32"
+                          disabled={controlsLocked || !canEditTargetField("bandwidth")}
                         />
-                        <Select value={unit} onValueChange={(value) => setUnit(value ?? "")}>
+                        <Select
+                          value={unit}
+                          onValueChange={(value) => setUnit(value ?? "")}
+                          disabled={controlsLocked || !canEditTargetField("bandwidth")}
+                        >
                           <SelectTrigger className="w-28" aria-label={t("Bandwidth Unit")}>
                             <SelectValue />
                           </SelectTrigger>
@@ -771,6 +893,34 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
                   </Field>
                 </div>
               )}
+
+              {bucketHistoricalFields.length || remoteTargetUnsupportedFields.length ? (
+                <fieldset className="space-y-3 border-t pt-4">
+                  <legend className="text-sm font-medium">{t("Advanced Settings")}</legend>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    {bucketHistoricalFields.map((field) => (
+                      <div key={field.name} className="space-y-1">
+                        <p className="text-xs text-muted-foreground">{field.name}</p>
+                        <p className="text-sm">
+                          <span className="inline-flex items-center rounded-none border border-dashed px-2 py-1 text-xs text-muted-foreground">
+                            {t("Read-only settings")}
+                          </span>
+                        </p>
+                      </div>
+                    ))}
+                    {remoteTargetUnsupportedFields.map((field) => (
+                      <div key={field.name} className="space-y-1">
+                        <p className="text-xs text-muted-foreground">{field.name}</p>
+                        <p className="text-sm">
+                          <span className="inline-flex items-center rounded-none border border-dashed px-2 py-1 text-xs text-muted-foreground">
+                            {t("Unsupported")}
+                          </span>
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </fieldset>
+              ) : null}
             </div>
           </div>
 
@@ -784,8 +934,8 @@ export function ReplicationNewForm({ open, onOpenChange, bucketName, onSuccess }
             >
               {t("Cancel")}
             </Button>
-            <Button type="submit" className="w-full sm:w-auto" disabled={submitting}>
-              {submitting ? t("Saving…") : t("Save")}
+            <Button type="submit" className="w-full sm:w-auto" disabled={controlsLocked}>
+              {submitting ? t("Saving…") : capabilitiesLoading ? t("Loading") : t("Save")}
             </Button>
           </DialogFooter>
         </form>

--- a/hooks/use-bucket.ts
+++ b/hooks/use-bucket.ts
@@ -355,6 +355,13 @@ export function useBucket() {
     [api],
   )
 
+  const listRemoteReplicationTargets = useCallback(
+    async (bucket: string) => {
+      return api.get(`/list-remote-targets?bucket=${encodeURIComponent(bucket)}`)
+    },
+    [api],
+  )
+
   const setRemoteReplicationTarget = useCallback(
     async (bucket: string, data: unknown) => {
       return api.put(`/set-remote-target?bucket=${encodeURIComponent(bucket)}`, data)
@@ -421,6 +428,7 @@ export function useBucket() {
     putBucketReplication,
     deleteBucketReplication,
     deleteRemoteReplicationTarget,
+    listRemoteReplicationTargets,
     setRemoteReplicationTarget,
     listBucketNotifications,
     putBucketNotifications,

--- a/hooks/use-runtime-capabilities.ts
+++ b/hooks/use-runtime-capabilities.ts
@@ -1,0 +1,46 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useApi } from "@/contexts/api-context"
+import { normalizeRuntimeCapabilities, type RuntimeCapabilitiesSnapshot } from "@/lib/runtime-capabilities"
+
+export function useRuntimeCapabilities() {
+  const api = useApi()
+  const [capabilities, setCapabilities] = useState<RuntimeCapabilitiesSnapshot | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadCapabilities = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const response = await api.get(api.resolveUrl("/rustfs/admin/v4/runtime/capabilities"), {
+        suppress403Redirect: true,
+      })
+      const normalized = normalizeRuntimeCapabilities(response)
+      setCapabilities(normalized.capabilities)
+      setError(normalized.error ?? null)
+    } catch (loadError) {
+      setCapabilities(null)
+      setError(
+        loadError instanceof Error && loadError.message
+          ? loadError.message
+          : "Replication capabilities are unavailable.",
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }, [api])
+
+  useEffect(() => {
+    void loadCapabilities()
+  }, [loadCapabilities])
+
+  return {
+    capabilities,
+    isLoading,
+    error,
+    reload: loadCapabilities,
+  }
+}

--- a/lib/runtime-capabilities.ts
+++ b/lib/runtime-capabilities.ts
@@ -1,0 +1,173 @@
+"use client"
+
+type JsonRecord = Record<string, unknown>
+
+export type RuntimeCapabilityFieldState = "supported" | "read_only_historical" | "unsupported"
+
+export interface RuntimeCapabilityField {
+  name: string
+  state: RuntimeCapabilityFieldState
+}
+
+export interface RuntimeCapabilityStatus {
+  state: string
+  reason?: string
+}
+
+export interface RuntimeCapabilityFeature {
+  contractVersion: number
+  status: RuntimeCapabilityStatus
+  fields: RuntimeCapabilityField[]
+}
+
+export interface RuntimeCapabilitiesSnapshot {
+  replication: {
+    contractVersion: number
+    bucketReplication: RuntimeCapabilityFeature
+    remoteTargets: RuntimeCapabilityFeature
+    mixedVersionPolicy: string
+  }
+  storageClasses: {
+    contractVersion: number
+    supportedWriteClasses: string[]
+    unsupportedWriteError: string
+    legacyLabelBehavior: string
+  }
+}
+
+export interface RuntimeCapabilitiesNormalization {
+  capabilities: RuntimeCapabilitiesSnapshot | null
+  error?: string
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" ? (value as JsonRecord) : {}
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : ""
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0
+}
+
+function normalizeStatus(value: unknown): RuntimeCapabilityStatus {
+  const record = asRecord(value)
+
+  return {
+    state: asString(record.state).toLowerCase(),
+    ...(asString(record.reason) ? { reason: asString(record.reason) } : {}),
+  }
+}
+
+function normalizeFieldState(value: unknown): RuntimeCapabilityFieldState {
+  const normalized = asString(value).toLowerCase()
+
+  if (normalized === "supported" || normalized === "read_only_historical" || normalized === "unsupported") {
+    return normalized
+  }
+
+  return "unsupported"
+}
+
+function normalizeFields(value: unknown): RuntimeCapabilityField[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.flatMap((item) => {
+    const record = asRecord(item)
+    const name = asString(record.name)
+    if (!name) return []
+
+    return [{ name, state: normalizeFieldState(record.state) }]
+  })
+}
+
+function normalizeFeature(value: unknown): RuntimeCapabilityFeature | null {
+  const record = asRecord(value)
+  const contractVersion = asNumber(record.contract_version)
+
+  if (contractVersion !== 1) {
+    return null
+  }
+
+  return {
+    contractVersion,
+    status: normalizeStatus(record.status),
+    fields: normalizeFields(record.fields),
+  }
+}
+
+export function normalizeRuntimeCapabilities(value: unknown): RuntimeCapabilitiesNormalization {
+  const record = asRecord(value)
+  const replication = normalizeFeature(record.replication)
+  const storageClasses = asRecord(record.storage_classes)
+
+  if (!replication) {
+    return {
+      capabilities: null,
+      error: "Versioned replication capabilities are unavailable on this server.",
+    }
+  }
+
+  const storageClassesVersion = asNumber(storageClasses.contract_version)
+  if (storageClassesVersion !== 1) {
+    return {
+      capabilities: null,
+      error: "Storage-class capabilities are unavailable on this server.",
+    }
+  }
+
+  const bucketReplication = normalizeFeature(replication ? asRecord(record.replication).bucket_replication : null)
+  const remoteTargets = normalizeFeature(replication ? asRecord(record.replication).remote_targets : null)
+
+  if (!bucketReplication || !remoteTargets) {
+    return {
+      capabilities: null,
+      error: "Replication capabilities are unavailable on this server.",
+    }
+  }
+
+  return {
+    capabilities: {
+      replication: {
+        contractVersion: asNumber(asRecord(record.replication).contract_version),
+        bucketReplication,
+        remoteTargets,
+        mixedVersionPolicy: asString(asRecord(record.replication).mixed_version_policy),
+      },
+      storageClasses: {
+        contractVersion: storageClassesVersion,
+        supportedWriteClasses: Array.isArray(storageClasses.supported_write_classes)
+          ? storageClasses.supported_write_classes.flatMap((item) => (typeof item === "string" && item ? [item] : []))
+          : [],
+        unsupportedWriteError: asString(storageClasses.unsupported_write_error),
+        legacyLabelBehavior: asString(storageClasses.legacy_label_behavior),
+      },
+    },
+  }
+}
+
+export function getRuntimeCapabilityFieldState(
+  capabilities: RuntimeCapabilitiesSnapshot | null,
+  feature: "bucketReplication" | "remoteTargets",
+  fieldName: string,
+): RuntimeCapabilityFieldState {
+  if (!capabilities) {
+    return "unsupported"
+  }
+
+  const capability = capabilities.replication[feature]
+  if (capability.status.state !== "supported") {
+    return "unsupported"
+  }
+
+  const fields = capability.fields
+  return fields.find((field) => field.name === fieldName)?.state ?? "unsupported"
+}
+
+export function isRuntimeCapabilitiesSupported(capabilities: RuntimeCapabilitiesSnapshot | null): boolean {
+  return Boolean(capabilities)
+}

--- a/tests/lib/bucket-settings-safety.test.js
+++ b/tests/lib/bucket-settings-safety.test.js
@@ -33,6 +33,10 @@ const replicationFormSource = await readFile(
   new URL("../../components/replication/new-form.tsx", import.meta.url),
   "utf8",
 )
+const runtimeCapabilitiesHookSource = await readFile(
+  new URL("../../hooks/use-runtime-capabilities.ts", import.meta.url),
+  "utf8",
+)
 const lifecycleFormSource = await readFile(new URL("../../components/lifecycle/new-form.tsx", import.meta.url), "utf8")
 const eventsFormSource = await readFile(new URL("../../components/events/new-form.tsx", import.meta.url), "utf8")
 const bucketHookSource = await readFile(new URL("../../hooks/use-bucket.ts", import.meta.url), "utf8")
@@ -218,6 +222,26 @@ test("replication creation rereads rules and never removes an uncertain remote t
   assert.match(replicationTabSource, /if \(\s*!role &&[\s\S]{0,120}!remaining\.some/)
   assert.doesNotMatch(replicationTabSource, /remaining\.length > 0 &&[\s\S]{0,80}!role &&/)
   assert.doesNotMatch(replicationTabSource, /Replication configuration Role is missing/)
+})
+
+test("replication controls fail closed on missing capabilities and preserve target identity", () => {
+  assert.match(runtimeCapabilitiesHookSource, /api\.resolveUrl\("\/rustfs\/admin\/v4\/runtime\/capabilities"\)/)
+  assert.match(replicationFormSource, /useRuntimeCapabilities/)
+  assert.match(replicationFormSource, /credentials: \{[\s\S]{0,100}accessKey,[\s\S]{0,100}secretKey,[\s\S]{0,100}\}/)
+  assert.match(replicationFormSource, /listRemoteReplicationTargets/)
+  assert.match(replicationFormSource, /controlsLocked/)
+  assert.match(replicationFormSource, /requiredBucketFieldsSupported/)
+  assert.match(replicationFormSource, /requiredTargetFieldsSupported/)
+  assert.match(replicationFormSource, /canEditTargetField\("healthCheckDuration"\)/)
+  assert.match(replicationFormSource, /canEditBucketField\("Rule\.DeleteReplication\.Status"\)/)
+  assert.match(replicationFormSource, /canEditBucketField\("Rule\.Filter\.Prefix"\)/)
+  assert.match(replicationFormSource, /Advanced Settings/)
+  assert.match(replicationFormSource, /currentTarget\.arn/)
+  assert.doesNotMatch(replicationFormSource, /expiration: "0001-01-01T00:00:00Z"/)
+  assert.doesNotMatch(replicationFormSource, /SseKmsEncryptedObjects/)
+  assert.match(replicationTabSource, /useRuntimeCapabilities/)
+  assert.match(replicationTabSource, /!canEditReplication/)
+  assert.match(replicationTabSource, /Replication rules unavailable/)
 })
 
 test("bucket setting controls expose names, field errors, and unresolved dependency states", () => {

--- a/tests/lib/runtime-capabilities.test.ts
+++ b/tests/lib/runtime-capabilities.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  getRuntimeCapabilityFieldState,
+  isRuntimeCapabilitiesSupported,
+  normalizeRuntimeCapabilities,
+} from "../../lib/runtime-capabilities"
+
+test("runtime capabilities normalize supported and historical replication fields", () => {
+  const normalized = normalizeRuntimeCapabilities({
+    replication: {
+      contract_version: 1,
+      bucket_replication: {
+        contract_version: 1,
+        status: { state: "supported", reason: "bucket replication is available" },
+        fields: [
+          { name: "Rule.DeleteReplication.Status", state: "supported" },
+          { name: "Destination.EncryptionConfiguration", state: "read_only_historical" },
+        ],
+      },
+      remote_targets: {
+        contract_version: 1,
+        status: { state: "supported", reason: "remote targets are available" },
+        fields: [
+          { name: "bandwidth", state: "supported" },
+          { name: "disableProxy", state: "unsupported" },
+        ],
+      },
+      mixed_version_policy: "fail_closed_when_capability_unknown_or_unsupported",
+    },
+    storage_classes: {
+      contract_version: 1,
+      supported_write_classes: ["STANDARD", "REDUCED_REDUNDANCY"],
+      unsupported_write_error: "InvalidStorageClass",
+      legacy_label_behavior: "normalized_to_effective_class",
+    },
+  })
+
+  assert.equal(isRuntimeCapabilitiesSupported(normalized.capabilities), true)
+  assert.equal(
+    getRuntimeCapabilityFieldState(normalized.capabilities, "bucketReplication", "Rule.DeleteReplication.Status"),
+    "supported",
+  )
+  assert.equal(
+    getRuntimeCapabilityFieldState(normalized.capabilities, "bucketReplication", "Destination.EncryptionConfiguration"),
+    "read_only_historical",
+  )
+  assert.equal(getRuntimeCapabilityFieldState(normalized.capabilities, "remoteTargets", "disableProxy"), "unsupported")
+  assert.deepEqual(normalized.capabilities?.storageClasses.supportedWriteClasses, ["STANDARD", "REDUCED_REDUNDANCY"])
+})
+
+test("runtime capabilities fail closed on unknown contract versions", () => {
+  const normalized = normalizeRuntimeCapabilities({
+    replication: {
+      contract_version: 2,
+      bucket_replication: {
+        contract_version: 1,
+        status: { state: "supported" },
+        fields: [],
+      },
+      remote_targets: {
+        contract_version: 1,
+        status: { state: "supported" },
+        fields: [],
+      },
+      mixed_version_policy: "fail_closed_when_capability_unknown_or_unsupported",
+    },
+    storage_classes: {
+      contract_version: 1,
+      supported_write_classes: ["STANDARD"],
+      unsupported_write_error: "InvalidStorageClass",
+      legacy_label_behavior: "normalized_to_effective_class",
+    },
+  })
+
+  assert.equal(normalized.capabilities, null)
+  assert.match(normalized.error ?? "", /unavailable/)
+  assert.equal(getRuntimeCapabilityFieldState(normalized.capabilities, "remoteTargets", "disableProxy"), "unsupported")
+})
+
+test("runtime capability fields fail closed when a feature is unavailable", () => {
+  const normalized = normalizeRuntimeCapabilities({
+    replication: {
+      contract_version: 1,
+      bucket_replication: {
+        contract_version: 1,
+        status: { state: "supported" },
+        fields: [{ name: "Rule.ID", state: "supported" }],
+      },
+      remote_targets: {
+        contract_version: 1,
+        status: { state: "unsupported", reason: "remote target routes are unavailable" },
+        fields: [{ name: "endpoint", state: "supported" }],
+      },
+      mixed_version_policy: "fail_closed_when_capability_unknown_or_unsupported",
+    },
+    storage_classes: {
+      contract_version: 1,
+      supported_write_classes: ["STANDARD"],
+      unsupported_write_error: "InvalidStorageClass",
+      legacy_label_behavior: "normalized_to_effective_class",
+    },
+  })
+
+  assert.equal(getRuntimeCapabilityFieldState(normalized.capabilities, "remoteTargets", "endpoint"), "unsupported")
+})


### PR DESCRIPTION
## Description

Consume the RustFS runtime capability contract in the console replication workflow so the UI only enables fields and actions supported by the connected server. Unknown or incompatible capability contracts fail closed, and remote target creation preserves an existing target ARN without sending unsupported server-managed fields.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed

```bash
pnpm test:run
pnpm type-check
pnpm lint
pnpm format:check
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

Related to rustfs/backlog#1614

## Screenshots (if applicable)

N/A

## Additional Notes

The UI requests `/rustfs/admin/v4/runtime/capabilities` with 403 redirect suppression and disables replication controls until the capability contract is loaded and verified.
