### PR TITLE
fix: skip decommission status for unsupported topology

### DIFF
--- a/app/(dashboard)/pool-decommission/page.tsx
+++ b/app/(dashboard)/pool-decommission/page.tsx
@@ -17,6 +17,7 @@ import { usePoolOperations } from "@/hooks/use-pool-operations"
 import { useDialog } from "@/lib/feedback/dialog"
 import { useMessage } from "@/lib/feedback/message"
 import { formatDateTime, formatInteger, niceBytes } from "@/lib/functions"
+import { loadPoolDecommissionData } from "@/lib/pool-decommission-load"
 import {
   deriveDecommissionDisplayState,
   deriveRebalanceDisplayState,
@@ -219,18 +220,17 @@ export default function PoolDecommissionPage() {
       setError(null)
       setRebalanceError(null)
       try {
-        const [overviewResult, rebalanceResult, decommissionResult] = await Promise.allSettled([
-          getPoolsOverview(),
-          getRebalanceStatus(),
-          getDecommissionStatuses(),
-        ])
+        const {
+          overview: nextOverview,
+          rebalanceResult,
+          decommissionStatuses,
+        } = await loadPoolDecommissionData({
+          getPoolsOverview,
+          getRebalanceStatus,
+          getDecommissionStatuses,
+        })
         if (!mountedRef.current || requestId !== requestVersionRef.current) return false
 
-        if (overviewResult.status === "rejected") throw overviewResult.reason
-        if (decommissionResult.status === "rejected") throw decommissionResult.reason
-
-        const nextOverview = overviewResult.value
-        const decommissionStatuses = decommissionResult.value
         const statusEntries = decommissionStatuses.map((status) => [status.poolId, status])
 
         setOverview(nextOverview)
@@ -661,7 +661,13 @@ export default function PoolDecommissionPage() {
                 </p>
               </div>
               <Badge variant={selectionLocked ? "outline" : "secondary"}>
-                {!dataReady || error || rebalanceError ? t("Unknown") : selectionLocked ? t("Running") : t("Ready")}
+                {!dataReady || error || rebalanceError
+                  ? t("Unknown")
+                  : overview.supportState === "unsupported"
+                    ? t("Unsupported")
+                    : selectionLocked
+                      ? t("Running")
+                      : t("Ready")}
               </Badge>
             </CardHeader>
             <CardContent className="space-y-5">

--- a/lib/pool-decommission-load.ts
+++ b/lib/pool-decommission-load.ts
@@ -1,0 +1,27 @@
+import type { DecommissionInfo, PoolsOverview, RebalanceStatus } from "@/lib/pool-operations"
+
+interface PoolDecommissionLoaders {
+  getPoolsOverview: () => Promise<PoolsOverview>
+  getRebalanceStatus: () => Promise<RebalanceStatus | null>
+  getDecommissionStatuses: () => Promise<DecommissionInfo[]>
+}
+
+export async function loadPoolDecommissionData({
+  getPoolsOverview,
+  getRebalanceStatus,
+  getDecommissionStatuses,
+}: PoolDecommissionLoaders) {
+  const overview = await getPoolsOverview()
+  const [rebalanceResult, decommissionResult] = await Promise.allSettled([
+    getRebalanceStatus(),
+    overview.supportState === "supported" ? getDecommissionStatuses() : Promise.resolve([]),
+  ])
+
+  if (decommissionResult.status === "rejected") throw decommissionResult.reason
+
+  return {
+    overview,
+    rebalanceResult,
+    decommissionStatuses: decommissionResult.value,
+  }
+}

--- a/tests/lib/pool-decommission-load.test.ts
+++ b/tests/lib/pool-decommission-load.test.ts
@@ -1,0 +1,98 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import { loadPoolDecommissionData } from "../../lib/pool-decommission-load"
+import { normalizePoolsOverview } from "../../lib/pool-operations"
+
+const singlePoolOverview = normalizePoolsOverview({ pools: [{ id: 1, status: "active" }] })
+const multiPoolOverview = normalizePoolsOverview({
+  pools: [
+    { id: 1, status: "active" },
+    { id: 2, status: "active" },
+  ],
+})
+
+test("unsupported single-pool topology skips decommission status and loads as unsupported", async () => {
+  let statusRequests = 0
+
+  const result = await loadPoolDecommissionData({
+    getPoolsOverview: async () => singlePoolOverview,
+    getRebalanceStatus: async () => null,
+    getDecommissionStatuses: async () => {
+      statusRequests += 1
+      throw new Error("501 Not Implemented")
+    },
+  })
+
+  assert.equal(statusRequests, 0)
+  assert.equal(result.overview.supportState, "unsupported")
+  assert.deepEqual(result.decommissionStatuses, [])
+})
+
+test("supported multi-pool topology requests decommission status", async () => {
+  let statusRequests = 0
+
+  await loadPoolDecommissionData({
+    getPoolsOverview: async () => multiPoolOverview,
+    getRebalanceStatus: async () => null,
+    getDecommissionStatuses: async () => {
+      statusRequests += 1
+      return []
+    },
+  })
+
+  assert.equal(statusRequests, 1)
+})
+
+test("overview failure rejects before dependent status reads", async () => {
+  let rebalanceRequests = 0
+  let statusRequests = 0
+
+  await assert.rejects(
+    loadPoolDecommissionData({
+      getPoolsOverview: async () => {
+        throw new Error("overview unavailable")
+      },
+      getRebalanceStatus: async () => {
+        rebalanceRequests += 1
+        return null
+      },
+      getDecommissionStatuses: async () => {
+        statusRequests += 1
+        return []
+      },
+    }),
+    /overview unavailable/,
+  )
+  assert.equal(rebalanceRequests, 0)
+  assert.equal(statusRequests, 0)
+})
+
+test("supported topology rejects a decommission status failure", async () => {
+  await assert.rejects(
+    loadPoolDecommissionData({
+      getPoolsOverview: async () => multiPoolOverview,
+      getRebalanceStatus: async () => null,
+      getDecommissionStatuses: async () => {
+        throw new Error("status unavailable")
+      },
+    }),
+    /status unavailable/,
+  )
+})
+
+test("page source keeps unsupported data separate from locked load failures", () => {
+  const source = fs.readFileSync("app/(dashboard)/pool-decommission/page.tsx", "utf8")
+
+  assert.match(source, /\{error \? \([\s\S]*?<AlertTitle>\{t\("Load Failed"\)\}<\/AlertTitle>/)
+  assert.match(
+    source,
+    /\{dataReady && overview\.supportState === "unsupported" \? \([\s\S]*?<AlertTitle>\{t\("Single pool decommission is not supported"\)\}<\/AlertTitle>/,
+  )
+  assert.match(source, /catch \(loadError\)[\s\S]*?setError\([\s\S]*?setDataReady\(false\)/)
+  assert.match(
+    source,
+    /const interactionLocked =[\s\S]*?Boolean\(error\)[\s\S]*?Boolean\(rebalanceError\)[\s\S]*?!dataReady/,
+  )
+  assert.match(source, /overview\.supportState === "unsupported"[\s\S]*?t\("Unsupported"\)/)
+})

--- a/tests/lib/pool-operations-safety.test.js
+++ b/tests/lib/pool-operations-safety.test.js
@@ -22,8 +22,10 @@ test("pool status reads fail closed instead of becoming idle or ready", () => {
 
 test("decommission keeps pool data visible when only rebalance status fails", () => {
   const source = read("app/(dashboard)/pool-decommission/page.tsx")
+  const loader = read("lib/pool-decommission-load.ts")
 
-  assert.match(source, /Promise\.allSettled\(/)
+  assert.match(source, /loadPoolDecommissionData\(/)
+  assert.match(loader, /Promise\.allSettled\(/)
   assert.match(source, /const \[rebalanceError, setRebalanceError\] = useState<string \| null>\(null\)/)
   assert.match(source, /setRebalanceState\("unknown"\)/)
   assert.match(source, /setDataReady\(true\)/)


### PR DESCRIPTION
## Description

Fix the Pool Decommission page so it determines topology support from the pools overview before requesting decommission status.

The page previously started `/pools/list`, `/rebalance/status`, and `/decommission/status` together. In a single-pool deployment, the backend intentionally does not provide decommission status and returns 501, so the otherwise valid unsupported topology was rendered as **Load Failed**.

This change:
- loads the pools overview first;
- skips `/decommission/status` when `supportState` is `unsupported`;
- renders the trusted single-pool state as **Unsupported** with no mutation actions;
- preserves fail-closed behavior for overview failures and supported-topology status failures;
- keeps rebalance and decommission status reads concurrent after a supported overview.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

```bash
pnpm install --frozen-lockfile
pnpm type-check
pnpm lint
pnpm test:run
pnpm prettier --check 'app/(dashboard)/pool-decommission/page.tsx' lib/pool-decommission-load.ts tests/lib/pool-decommission-load.test.ts tests/lib/pool-operations-safety.test.js
git diff --check
```

- `pnpm test:run`: 392 tests passed.
- Deterministic regression coverage verifies unsupported single-pool status calls are 0, supported multi-pool status calls occur, overview failures stop dependent reads, and supported status failures reject.
- Adversarial reviewer, tester, UX, and simplifier passes completed.
- Full `pnpm format:check` remains blocked by the unchanged upstream file `components/object/tiff-viewer.tsx`; every file in this PR passes Prettier.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

Fixes rustfs/rustfs#5773

## Screenshots (if applicable)

The after captures use a deterministic local mock with one active 1 TiB pool. The mock returns 501 for `/decommission/status`, matching the reported backend behavior.

### Before

![Single-pool page showing Load Failed](https://github.com/user-attachments/assets/48c9ade2-165e-48c9-afbd-16e50d365b27)

### After

#### Desktop

![Single-pool page showing Unsupported](https://raw.githubusercontent.com/ccccpj/console/agent/issue-5773-screenshots/.github/screenshots/issue-5773/after-desktop.png)

#### Mobile

![Single-pool page showing Unsupported on mobile](https://raw.githubusercontent.com/ccccpj/console/agent/issue-5773-screenshots/.github/screenshots/issue-5773/after-mobile.png)

## Additional Notes

This PR does not change the RustFS backend's 501 contract for unsupported single-pool decommission status. Supported multi-pool status failures continue to render an error and keep interactions locked.