### PR TITLE
fix: render audio object previews natively

### DIFF
--- a/components/object/preview-modal.tsx
+++ b/components/object/preview-modal.tsx
@@ -10,6 +10,7 @@ import { RiFullscreenExitLine, RiFullscreenLine } from "@remixicon/react"
 import { PdfViewer } from "@/components/object/pdf-viewer"
 import { ParquetViewer } from "@/components/object/parquet-viewer"
 import { TiffViewer } from "@/components/object/tiff-viewer"
+import { getObjectPreviewMode, normalizePreviewContentType } from "@/lib/object-preview"
 import Image from "next/image"
 
 const SAFE_TEXT_MIMES = [
@@ -26,8 +27,6 @@ const SAFE_TEXT_MIMES = [
 const SAFE_TEXT_EXTENSIONS = [".txt", ".json", ".jsonl", ".ndjson", ".xml", ".csv", ".md", ".yml", ".yaml"]
 const SAFE_IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".ico", ".tif", ".tiff"]
 const ALLOWED_SIZE = 1024 * 1024 * 2 // 2MB
-
-type PreviewMode = "text" | "image" | "pdf" | "parquet" | "sandbox" | "download" | "tiff"
 
 const PARQUET_MIMES = ["application/vnd.apache.parquet", "application/x-parquet", "application/parquet"]
 const PARQUET_EXTENSIONS = [".parquet", ".pq"]
@@ -52,10 +51,6 @@ type FullscreenElement = HTMLElement & {
   webkitRequestFullscreen?: () => Promise<void> | void
 }
 
-function normalizeContentType(contentType: string) {
-  return contentType.split(";")[0]?.trim().toLowerCase() ?? ""
-}
-
 function isSafeTextPreview(contentType: string, objectKey: string, objectSize: number) {
   if (objectSize > ALLOWED_SIZE) return false
   if (SAFE_TEXT_MIMES.includes(contentType)) return true
@@ -69,12 +64,6 @@ function isImagePreview(contentType: string, objectKey: string) {
   if (isSvg) return false
   if (contentType.startsWith("image/")) return true
   return SAFE_IMAGE_EXTENSIONS.some((ext) => keyLower.endsWith(ext))
-}
-
-function getPreviewMode(hasPreviewUrl: boolean, canRenderText: boolean, canRenderImage: boolean): PreviewMode {
-  if (!hasPreviewUrl) return "download"
-  if (canRenderImage) return "image"
-  return canRenderText ? "text" : "sandbox"
 }
 
 function isPdfPreview(contentType: string) {
@@ -124,6 +113,7 @@ export function ObjectPreviewModal({ show, onShowChange, object }: ObjectPreview
   const { t } = useTranslation()
   const [textContent, setTextContent] = React.useState("")
   const [loading, setLoading] = React.useState(false)
+  const [audioLoadError, setAudioLoadError] = React.useState(false)
   const [isFormatted, setIsFormatted] = React.useState(true)
   const [imageNaturalSize, setImageNaturalSize] = React.useState<{ width: number; height: number } | null>(null)
   const [imageFitScale, setImageFitScale] = React.useState(1)
@@ -139,7 +129,7 @@ export function ObjectPreviewModal({ show, onShowChange, object }: ObjectPreview
   const objectSize = Number(object?.ContentLength ?? 0)
   const objectKey = object?.Key ?? ""
   const objectKeyLower = objectKey.toLowerCase()
-  const normalizedContentType = normalizeContentType(contentType)
+  const normalizedContentType = normalizePreviewContentType(contentType)
 
   const isJson = normalizedContentType === "application/json" || objectKeyLower.endsWith(".json")
   const canRenderText = hasPreviewUrl && isSafeTextPreview(normalizedContentType, objectKey, objectSize)
@@ -147,13 +137,15 @@ export function ObjectPreviewModal({ show, onShowChange, object }: ObjectPreview
   const canRenderPdf = hasPreviewUrl && isPdfPreview(normalizedContentType)
   const canRenderParquet = hasPreviewUrl && isParquetPreview(normalizedContentType, objectKey)
   const canRenderTiff = hasPreviewUrl && isTiffPreview(objectKey)
-  const previewMode: PreviewMode = canRenderParquet
-    ? "parquet"
-    : canRenderPdf
-      ? "pdf"
-      : canRenderTiff
-        ? "tiff"
-        : getPreviewMode(hasPreviewUrl, canRenderText, canRenderImage)
+  const previewMode = getObjectPreviewMode({
+    hasPreviewUrl,
+    contentType,
+    canRenderText,
+    canRenderImage,
+    canRenderPdf,
+    canRenderParquet,
+    canRenderTiff,
+  })
   const isImageMode = previewMode === "image"
   const isSelfScrollMode = isImageMode || previewMode === "parquet" || previewMode === "tiff"
 
@@ -192,6 +184,10 @@ export function ObjectPreviewModal({ show, onShowChange, object }: ObjectPreview
       setLoading(false)
     }
   }, [show, previewMode, previewUrl, t])
+
+  React.useEffect(() => {
+    setAudioLoadError(false)
+  }, [show, previewUrl])
 
   React.useEffect(() => {
     const cachedSize = previewUrl ? imageSizeCacheRef.current[previewUrl] : undefined
@@ -374,6 +370,20 @@ export function ObjectPreviewModal({ show, onShowChange, object }: ObjectPreview
               </div>
             </div>
           </div>
+        )
+      case "audio":
+        return audioLoadError ? (
+          <div className="my-auto text-center text-sm text-destructive" role="alert">
+            {t("Preview unavailable")}
+          </div>
+        ) : (
+          <audio
+            controls
+            src={previewUrl}
+            className="my-auto w-full"
+            aria-label={objectKey || t("Preview")}
+            onError={() => setAudioLoadError(true)}
+          />
         )
       case "sandbox":
         return (

--- a/lib/object-preview.ts
+++ b/lib/object-preview.ts
@@ -1,0 +1,33 @@
+type ObjectPreviewMode = "text" | "image" | "audio" | "pdf" | "parquet" | "sandbox" | "download" | "tiff"
+
+interface ObjectPreviewOptions {
+  hasPreviewUrl: boolean
+  contentType: string
+  canRenderText: boolean
+  canRenderImage: boolean
+  canRenderPdf: boolean
+  canRenderParquet: boolean
+  canRenderTiff: boolean
+}
+
+export function normalizePreviewContentType(contentType: string) {
+  return contentType.split(";")[0]?.trim().toLowerCase() ?? ""
+}
+
+export function getObjectPreviewMode({
+  hasPreviewUrl,
+  contentType,
+  canRenderText,
+  canRenderImage,
+  canRenderPdf,
+  canRenderParquet,
+  canRenderTiff,
+}: ObjectPreviewOptions): ObjectPreviewMode {
+  if (!hasPreviewUrl) return "download"
+  if (normalizePreviewContentType(contentType).startsWith("audio/")) return "audio"
+  if (canRenderParquet) return "parquet"
+  if (canRenderPdf) return "pdf"
+  if (canRenderTiff) return "tiff"
+  if (canRenderImage) return "image"
+  return canRenderText ? "text" : "sandbox"
+}

--- a/tests/lib/object-preview-source.test.js
+++ b/tests/lib/object-preview-source.test.js
@@ -1,6 +1,46 @@
 import test from "node:test"
 import assert from "node:assert/strict"
 import fs from "node:fs"
+import { getObjectPreviewMode } from "../../lib/object-preview.ts"
+
+const previewOptions = {
+  hasPreviewUrl: true,
+  contentType: "application/octet-stream",
+  canRenderText: false,
+  canRenderImage: false,
+  canRenderPdf: false,
+  canRenderParquet: false,
+  canRenderTiff: false,
+}
+
+test("object preview dispatches normalized audio MIME types to the native audio mode", () => {
+  assert.equal(getObjectPreviewMode({ ...previewOptions, contentType: "audio/wav" }), "audio")
+  assert.equal(getObjectPreviewMode({ ...previewOptions, contentType: "audio/mpeg" }), "audio")
+  assert.equal(getObjectPreviewMode({ ...previewOptions, contentType: " Audio/WAV; codecs=1 " }), "audio")
+  assert.equal(
+    getObjectPreviewMode({ ...previewOptions, contentType: "audio/wav", canRenderParquet: true, canRenderTiff: true }),
+    "audio",
+  )
+})
+
+test("object preview preserves non-audio dispatch behavior", () => {
+  assert.equal(getObjectPreviewMode(previewOptions), "sandbox")
+  assert.equal(getObjectPreviewMode({ ...previewOptions, canRenderPdf: true }), "pdf")
+  assert.equal(getObjectPreviewMode({ ...previewOptions, canRenderImage: true }), "image")
+  assert.equal(getObjectPreviewMode({ ...previewOptions, canRenderText: true }), "text")
+})
+
+test("object preview renders native audio controls without relaxing the fallback sandbox", () => {
+  const source = fs.readFileSync("components/object/preview-modal.tsx", "utf8")
+
+  assert.match(source, /const previewMode = getObjectPreviewMode\(\{/)
+  assert.match(source, /switch \(previewMode\)/)
+  assert.match(source, /case "audio":[\s\S]*<audio[\s\S]*controls[\s\S]*src=\{previewUrl\}/)
+  assert.match(source, /onError=\{\(\) => setAudioLoadError\(true\)\}/)
+  assert.match(source, /role="alert"[\s\S]*\{t\("Preview unavailable"\)\}/)
+  assert.match(source, /<iframe[^>]*sandbox=""/)
+  assert.doesNotMatch(source, /allow-same-origin/)
+})
 
 test("object preview modal falls back when standard fullscreen APIs are unavailable", () => {
   const source = fs.readFileSync("components/object/preview-modal.tsx", "utf8")


### PR DESCRIPTION
# Pull Request

## Description

Render object previews with normalized `audio/*` Content-Types through the browser's native `<audio controls>` element.

The previous generic fallback loaded audio inside `iframe sandbox=""`. That sandbox creates an opaque origin, so ranged media requests can be sent as `Origin: null` and rejected by the object endpoint's CORS policy. The dedicated audio mode keeps the generic iframe sandbox strict, avoids broadening RustFS CORS, and avoids fetching entire objects into blobs.

Audio loading failures now render the existing localized `Preview unavailable` alert. Existing text, image, PDF, Parquet, TIFF, unknown-type, and no-URL behavior remains unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

```bash
pnpm install --frozen-lockfile
pnpm type-check
pnpm lint
pnpm test:run
pnpm prettier --check components/object/preview-modal.tsx lib/object-preview.ts tests/lib/object-preview-source.test.js
git diff --check
```

- `pnpm test:run`: 390/390 passed.
- Deterministic local PCM WAV harness: the legacy sandbox path sent `Origin: null` with `Range: bytes=0-` and stayed at `0:00 / 0:00`; the native audio path reached `readyState=4`, played to 2 seconds by keyboard, and received `206 Partial Content` with no relevant browser errors.
- `pnpm format:check` is currently blocked by an untouched upstream formatting issue in `components/object/tiff-viewer.tsx`; all files changed by this PR pass Prettier.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

Fixes rustfs/rustfs#5788

## Screenshots (if applicable)

The captures below use a deterministic local harness with a valid 8 kHz mono PCM WAV and `Content-Type: audio/wav`. They demonstrate the preview DOM/media behavior without claiming a live RustFS deployment.

### Before — generic sandbox iframe

Legacy audio preview displayed disabled controls at `0:00 / 0:00`; DOM inspection confirmed `iframe sandbox=""`, and the ranged media request carried `Origin: null`.

![Before: WAV preview through the strict sandbox iframe](https://github.com/user-attachments/assets/e50b25b8-2fc2-47ab-8882-8511d9748599)

### After — native audio controls

The native audio preview loaded the 2-second WAV, remained keyboard-operable, and completed playback with a normal Range/206 response.

![After: WAV preview through native audio controls](https://github.com/user-attachments/assets/5301ce4e-761e-4060-a399-1fb364bc57e1)

## Additional Notes

- The generic iframe remains `sandbox=""`; this PR does not add `allow-same-origin`.
- No RustFS backend CORS behavior is changed.
- Explicit normalized `audio/*` MIME types take priority over extension-based Parquet/TIFF detection.
- Independent reviewer, tester, UX auditor, and simplifier passes found no remaining blocking issues.
