### PR TITLE
fix: allow access key expiration beyond current year

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,8 @@ Scale rigor to the change: a one-line fix needs a quick reviewer + tester pass; 
 
 # This is NOT the Next.js you know
 
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
 
-**Keep this block, including in commits.** It is part of the project's agent setup, maintained by `next dev` for every agent that works here. If it appears as an uncommitted change, that is intentional — commit it as-is. Do not remove it to clean up a diff; it will be regenerated.
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
 
 <!-- END:nextjs-agent-rules -->

--- a/components/datetime-picker.tsx
+++ b/components/datetime-picker.tsx
@@ -155,7 +155,7 @@ export function DateTimePicker({
           onSelect={updateDate}
           disabled={disabledDays}
           locale={calendarLocale}
-          captionLayout="dropdown"
+          captionLayout="dropdown-months"
         />
         <div className="flex items-center gap-2 border-t p-2.5">
           <div className="flex min-w-0 flex-1 items-center gap-2">

--- a/tests/lib/datetime-picker.test.js
+++ b/tests/lib/datetime-picker.test.js
@@ -1,6 +1,9 @@
 import test from "node:test"
 import assert from "node:assert/strict"
 import fs from "node:fs"
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { DayPicker } from "react-day-picker"
 
 import {
   applyDateTimeBounds,
@@ -92,4 +95,23 @@ test("DateTimePicker keeps the calendar date selected when clicked again", () =>
 
   assert.equal(source.includes('mode="single"'), true)
   assert.equal(source.includes("required"), true)
+})
+
+test("DateTimePicker does not cap navigation at the current year", () => {
+  const source = fs.readFileSync("components/datetime-picker.tsx", "utf8")
+  const captionLayout = source.match(/captionLayout="([^"]+)"/)?.[1]
+
+  assert.equal(captionLayout, "dropdown-months")
+
+  const markup = renderToStaticMarkup(
+    React.createElement(DayPicker, {
+      captionLayout,
+      month: new Date(2026, 11, 1),
+      today: new Date(2026, 7, 9),
+    }),
+  )
+  const nextMonthButton = markup.match(/<button[^>]+aria-label="Go to the Next Month"[^>]*>/)?.[0]
+
+  assert.ok(nextMonthButton)
+  assert.doesNotMatch(nextMonthButton, /aria-disabled="true"/)
 })


### PR DESCRIPTION
# Pull Request

## Description

Fix the shared date-time picker so access key expiration dates can navigate beyond the end of the current year. `react-day-picker` implicitly limits `captionLayout="dropdown"` to the current year when no explicit end month is provided; using the month-only dropdown preserves month selection without introducing an arbitrary future limit.

Add a regression test that renders the real DayPicker configuration at December 2026 and verifies that navigation to the next month remains enabled. The PR also retains the Next.js-generated `AGENTS.md` guidance refresh required by the repository.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

```bash
pnpm install --frozen-lockfile --registry=https://registry.npmmirror.com
pnpm test:run
pnpm type-check
pnpm lint
pnpm prettier --check components/datetime-picker.tsx tests/lib/datetime-picker.test.js
git diff --check
```

Manually verified navigation from August 2026 through January 2027, date selection in 2027, keyboard-accessible controls, and layout at desktop and 375px mobile widths with no console warnings or horizontal overflow.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

N/A

## Screenshots (if applicable)

N/A — this changes calendar navigation behavior without changing visual styling.

## Additional Notes

The full-repository Prettier check still reports the pre-existing, unchanged `components/object/tiff-viewer.tsx` on `origin/main`; both files changed by this fix pass Prettier.
