### PR TITLE
fix: reconcile single-node SNSD topology

### DIFF
--- a/lib/performance-data.ts
+++ b/lib/performance-data.ts
@@ -29,7 +29,7 @@ export interface ClusterDiagnostics {
   listingHealth: StatusDiagnostic
   workloadAdmission: StatusDiagnostic
   peers: PeerHealthDiagnostic[]
-  membership: Array<{ nodeId: string; gridHost?: string; isLocal?: boolean }>
+  membership: Array<{ nodeId: string; gridHost?: string; serverInfoEndpoint?: string; isLocal?: boolean }>
   topologyDrives: Array<{
     nodeId: string
     poolIndex?: number
@@ -393,8 +393,18 @@ export function normalizeClusterDiagnostics(value: unknown): ClusterDiagnostics 
     const nodeId = asSafeText(node.node_id ?? node.nodeId ?? node.NodeId)
     if (!nodeId) return []
     const gridHost = asSafeText(node.grid_host ?? node.gridHost ?? node.GridHost)
+    const serverInfoEndpoint = asSafeText(
+      node.server_info_endpoint ?? node.serverInfoEndpoint ?? node.ServerInfoEndpoint,
+    )
     const isLocal = asBoolean(node.is_local ?? node.isLocal ?? node.IsLocal)
-    return [{ nodeId, ...(gridHost ? { gridHost } : {}), ...(isLocal !== undefined ? { isLocal } : {}) }]
+    return [
+      {
+        nodeId,
+        ...(gridHost ? { gridHost } : {}),
+        ...(serverInfoEndpoint ? { serverInfoEndpoint } : {}),
+        ...(isLocal !== undefined ? { isLocal } : {}),
+      },
+    ]
   })
   const topologyDrives = asArray<unknown>(membershipRecord.drives ?? membershipRecord.Drives).flatMap((value) => {
     const drive = asRecord(value)
@@ -527,9 +537,11 @@ function getEndpointIdentity(value: string | undefined) {
 }
 
 function getMemberIdentities(member: ClusterDiagnostics["membership"][number]) {
-  return [getEndpointIdentity(member.nodeId), getEndpointIdentity(member.gridHost)].filter(
-    (identity): identity is NonNullable<ReturnType<typeof getEndpointIdentity>> => Boolean(identity),
-  )
+  return [
+    getEndpointIdentity(member.serverInfoEndpoint),
+    getEndpointIdentity(member.nodeId),
+    getEndpointIdentity(member.gridHost),
+  ].filter((identity): identity is NonNullable<ReturnType<typeof getEndpointIdentity>> => Boolean(identity))
 }
 
 function findMatchingMember(server: ServerInfo, diagnostics: ClusterDiagnostics) {
@@ -726,6 +738,14 @@ function reconcileTopologyServers(system: SystemInfo, diagnostics: ClusterDiagno
       servers: system.servers,
       reportedServers: system.servers?.length,
       expectedServers: undefined,
+    }
+  }
+
+  if (membership.length === 1 && membership[0].isLocal && reportedServers.length === 1) {
+    return {
+      servers: reportedServers,
+      reportedServers: 1,
+      expectedServers: 1,
     }
   }
 

--- a/tests/lib/performance-data.test.js
+++ b/tests/lib/performance-data.test.js
@@ -555,6 +555,105 @@ test("the #1429 reporter payload uses v4 membership without duplicating v3 rows"
   })
 })
 
+test("a single local path member reuses the only reported SNSD server", () => {
+  const system = normalizeSystemInfo({
+    info: {
+      backend: { onlineDisks: 1, offlineDisks: 0, unknownDisks: 0, totalDrivesPerSet: [1] },
+      servers: [
+        {
+          endpoint: ":::9000",
+          state: "online",
+          uptime: 42,
+          drives: [{ state: "ok" }],
+          network: { "::": "online" },
+        },
+      ],
+    },
+  })
+  const diagnostics = normalizeClusterDiagnostics({
+    snapshot: {
+      membership: {
+        nodes: [{ node_id: "local", grid_host: "", is_local: true }],
+        drives: [{ pool_index: 0, set_index: 0, disk_index: 0, node_id: "local" }],
+      },
+      pool_state: { pools: [{ pool_index: 0, set_count: 1, drives_per_set: 1, endpoint_count: 1 }] },
+    },
+  })
+
+  const view = buildRunningStatusView(system, diagnostics)
+
+  assert.deepEqual(
+    view.servers?.map((server) => server.endpoint),
+    [":::9000"],
+  )
+  assert.deepEqual(view.serverSummary, {
+    online: 1,
+    offline: 0,
+    degraded: 0,
+    initializing: 0,
+    unknown: 0,
+  })
+  assert.equal(view.topology.reportedServers, 1)
+  assert.equal(view.topology.expectedServers, 1)
+  assert.equal(view.topology.incomplete, false)
+})
+
+test("a local server-info identity matches without guessing among multiple members", () => {
+  const system = normalizeSystemInfo({
+    info: {
+      backend: { onlineDisks: 2, offlineDisks: 0, unknownDisks: 0 },
+      servers: [
+        { endpoint: ":::9000", state: "online", drives: [{ state: "ok" }] },
+        { endpoint: "node-b:9000", state: "online", drives: [{ state: "ok" }] },
+      ],
+    },
+  })
+  const diagnostics = normalizeClusterDiagnostics({
+    snapshot: {
+      membership: {
+        nodes: [
+          { node_id: "local", is_local: true, server_info_endpoint: ":::9000" },
+          { node_id: "node-b:9000", grid_host: "http://node-b:9000", is_local: false },
+        ],
+      },
+    },
+  })
+
+  const view = buildRunningStatusView(system, diagnostics)
+
+  assert.deepEqual(
+    view.servers?.map((server) => server.endpoint),
+    [":::9000", "node-b:9000"],
+  )
+  assert.equal(view.topology.reportedServers, 2)
+  assert.equal(view.topology.expectedServers, 2)
+  assert.equal(view.topology.incomplete, false)
+})
+
+test("a local member stays unresolved when multiple reported servers are ambiguous", () => {
+  const system = normalizeSystemInfo({
+    info: {
+      servers: [
+        { endpoint: "node-a:9000", state: "online" },
+        { endpoint: "node-b:9000", state: "online" },
+      ],
+    },
+  })
+  const diagnostics = normalizeClusterDiagnostics({
+    snapshot: { membership: { nodes: [{ node_id: "local", is_local: true }] } },
+  })
+
+  const view = buildRunningStatusView(system, diagnostics)
+
+  assert.deepEqual(
+    view.servers?.map((server) => server.endpoint),
+    ["local", "node-a:9000", "node-b:9000"],
+  )
+  assert.equal(view.topology.reportedServers, 0)
+  assert.equal(view.topology.expectedServers, 1)
+  assert.equal(view.topology.incomplete, true)
+})
+
 test("a v3-only incomplete drive denominator is unknown without inventing a server denominator", () => {
   const view = buildRunningStatusView(normalizeSystemInfo(reporterV3Payload))
 


### PR DESCRIPTION
# Pull Request

## Description

Reconcile a single local path-based SNSD membership with the only v3 ServerInfo row, and consume the optional `server_info_endpoint` identity supplied by newer RustFS snapshots. Ambiguous multi-server payloads remain unresolved instead of being guessed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed

```bash
pnpm install --frozen-lockfile
pnpm type-check
pnpm lint
pnpm exec prettier --check lib/performance-data.ts tests/lib/performance-data.test.js
pnpm test:run
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

Related to rustfs/rustfs#5870

## Screenshots (if applicable)

N/A — this changes reconciliation data only; no visual markup or styling changed.

## Additional Notes

The fallback is intentionally limited to exactly one local membership and exactly one reported server. Multi-server ambiguity continues to surface as incomplete topology.
