### PR TITLE
fix: support noncurrent delete-marker cleanup

### DIFF
--- a/components/lifecycle/new-form.tsx
+++ b/components/lifecycle/new-form.tsx
@@ -19,6 +19,7 @@ import { isMissingBucketConfiguration } from "@/lib/bucket-configuration"
 import {
   buildCurrentVersionExpirationRules,
   buildLifecycleFilter,
+  buildNoncurrentVersionExpirationRule,
   findIncompleteLifecycleTag,
   getBucketVersioningMode,
   hasCompleteLifecycleTags,
@@ -128,10 +129,6 @@ export function LifecycleNewForm({ open, onOpenChange, bucketName, onSuccess }: 
   }, [open, loadTiers, loadVersioningStatus, tiersReloadVersion, versioningReloadVersion])
 
   useEffect(() => {
-    if (activeTab !== "expire" || versionType !== "current") setExpiredDeleteMark(false)
-  }, [activeTab, versionType])
-
-  useEffect(() => {
     if (!hasVersionHistory) {
       setVersionType("current")
       setExpiredDeleteMark(false)
@@ -186,7 +183,7 @@ export function LifecycleNewForm({ open, onOpenChange, bucketName, onSuccess }: 
     if (incompleteTagIndex >= 0) {
       errors.tags = tags[incompleteTagIndex].key.trim() ? t("Please enter tag value") : t("Please enter key name")
     }
-    if (activeTab === "expire" && versionType === "current" && expiredDeleteMark && hasCompleteLifecycleTags(tags)) {
+    if (activeTab === "expire" && expiredDeleteMark && hasCompleteLifecycleTags(tags)) {
       errors.deleteMarker = `${t("Delete Marker Handling")}: ${t("Tags")} ${t("Unsupported")}`
     }
 
@@ -243,8 +240,7 @@ export function LifecycleNewForm({ open, onOpenChange, bucketName, onSuccess }: 
 
       if (activeTab === "expire") {
         if (versionType === "non-current") {
-          baseRule.NoncurrentVersionExpiration = { NoncurrentDays: daysValue }
-          newRules = [baseRule]
+          newRules = [buildNoncurrentVersionExpirationRule(baseId, daysValue, filter, expiredDeleteMark)]
         } else {
           newRules = buildCurrentVersionExpirationRules(baseId, daysValue, filter, expiredDeleteMark)
         }
@@ -490,7 +486,7 @@ export function LifecycleNewForm({ open, onOpenChange, bucketName, onSuccess }: 
                   </div>
                 </details>
 
-                {hasVersionHistory && versionType === "current" && (
+                {hasVersionHistory && (
                   <details>
                     <summary className="cursor-pointer text-sm font-medium text-primary">
                       {t("Advanced Settings")}
@@ -539,7 +535,7 @@ export function LifecycleNewForm({ open, onOpenChange, bucketName, onSuccess }: 
                   </Alert>
                 ) : null}
 
-                {activeTab === "expire" && expiredDeleteMark ? (
+                {activeTab === "expire" && versionType === "current" && expiredDeleteMark ? (
                   <p className="text-sm text-muted-foreground">{t("2 lifecycle rules will be created.")}</p>
                 ) : null}
               </TabsContent>

--- a/lib/bucket-lifecycle.ts
+++ b/lib/bucket-lifecycle.ts
@@ -68,3 +68,18 @@ export function buildCurrentVersionExpirationRules(
 
   return rules
 }
+
+export function buildNoncurrentVersionExpirationRule(
+  id: string,
+  days: number,
+  filter: Record<string, unknown>,
+  cleanupExpiredDeleteMarkers: boolean,
+): Record<string, unknown> {
+  return {
+    ID: id,
+    Status: "Enabled",
+    Filter: filter,
+    NoncurrentVersionExpiration: { NoncurrentDays: days },
+    ...(cleanupExpiredDeleteMarkers ? { Expiration: { ExpiredObjectDeleteMarker: true } } : {}),
+  }
+}

--- a/tests/lib/bucket-settings-safety.test.js
+++ b/tests/lib/bucket-settings-safety.test.js
@@ -11,6 +11,7 @@ import {
 import {
   buildCurrentVersionExpirationRules,
   buildLifecycleFilter,
+  buildNoncurrentVersionExpirationRule,
   findIncompleteLifecycleTag,
   getBucketVersioningMode,
   hasCompleteLifecycleTags,
@@ -155,6 +156,39 @@ test("AWS SDK serializes expiration days and delete-marker cleanup as two valid 
   assert.deepEqual(expirations, ["<Days>30</Days>", "<ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker>"])
 })
 
+test("noncurrent expiration and delete-marker cleanup serialize as one rule without current expiry", async () => {
+  let requestBody = ""
+  const client = new S3Client({
+    region: "us-east-1",
+    endpoint: "http://127.0.0.1:9000",
+    credentials: { accessKeyId: "test", secretAccessKey: "test" },
+    requestHandler: {
+      async handle(request) {
+        requestBody = typeof request.body === "string" ? request.body : new TextDecoder().decode(request.body)
+        return { response: { statusCode: 200, headers: {}, body: new Uint8Array() } }
+      },
+    },
+  })
+
+  await client.send(
+    new PutBucketLifecycleConfigurationCommand({
+      Bucket: "test-bucket",
+      LifecycleConfiguration: {
+        Rules: [buildNoncurrentVersionExpirationRule("rule", 1, { Prefix: "" }, true)],
+      },
+    }),
+  )
+  client.destroy()
+
+  assert.equal((requestBody.match(/<Rule>/g) ?? []).length, 1)
+  assert.match(
+    requestBody,
+    /<NoncurrentVersionExpiration><NoncurrentDays>1<\/NoncurrentDays><\/NoncurrentVersionExpiration>/,
+  )
+  assert.match(requestBody, /<Expiration><ExpiredObjectDeleteMarker>true<\/ExpiredObjectDeleteMarker><\/Expiration>/)
+  assert.doesNotMatch(requestBody, /<Expiration><(?:Days|Date)>/)
+})
+
 test("lifecycle helpers preserve suspended versioning and reject partial tag pairs", () => {
   assert.equal(MAX_LIFECYCLE_RULES, 1000)
   assert.equal(getBucketVersioningMode("Enabled"), "enabled")
@@ -171,11 +205,19 @@ test("lifecycle helpers preserve suspended versioning and reject partial tag pai
     lifecycleFormSource,
     /buildCurrentVersionExpirationRules\(baseId, daysValue, filter, expiredDeleteMark\)/,
   )
+  assert.match(
+    lifecycleFormSource,
+    /buildNoncurrentVersionExpirationRule\(baseId, daysValue, filter, expiredDeleteMark\)/,
+  )
   assert.match(lifecycleFormSource, /Rules: \[\.\.\.existingRules, \.\.\.newRules\]/)
   assert.match(lifecycleFormSource, /existingRules\.length \+ newRules\.length > MAX_LIFECYCLE_RULES/)
   assert.match(lifecycleFormSource, /const hasVersionHistory = versioningMode !== "unversioned"/)
-  assert.match(lifecycleFormSource, /expiredDeleteMark && hasCompleteLifecycleTags\(tags\)/)
+  assert.match(lifecycleFormSource, /activeTab === "expire" && expiredDeleteMark && hasCompleteLifecycleTags\(tags\)/)
   assert.match(lifecycleFormSource, /setExpiredDeleteMark\(checked === true\)/)
+  assert.doesNotMatch(
+    lifecycleFormSource,
+    /activeTab !== "expire" \|\| versionType !== "current"\) setExpiredDeleteMark\(false\)/,
+  )
 })
 
 test("bucket reads fail closed and stale responses cannot update the active bucket", () => {


### PR DESCRIPTION
## Summary
- expose expired delete-marker cleanup for noncurrent expiration in the Console
- preserve the checkbox across version-mode changes and emit one combined NVE + EODM rule
- reject tag filters with EODM before submission

## Root cause
The form only rendered cleanup for current-version expiration and cleared the selection when switching modes, so it could not express the S3-compatible noncurrent-only rule from rustfs/backlog#1849.

## Backlog
Refs rustfs/backlog#1849

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm type-check`
- `pnpm lint`
- touched-file `pnpm prettier --check`
- `pnpm test:run` (397 passed)

The repository-wide format check still reports the pre-existing unmodified `components/object/tiff-viewer.tsx` formatting issue.