### PR TITLE
fix(replication): stop gating capabilities on exact contract versions

### DIFF
--- a/lib/runtime-capabilities.ts
+++ b/lib/runtime-capabilities.ts
@@ -85,11 +85,26 @@ function normalizeFields(value: unknown): RuntimeCapabilityField[] {
   })
 }
 
+/**
+ * The contract version only describes the shape of a capability block, which
+ * has been stable since v1. Servers bump it whenever the *semantics* of a
+ * field change (remote targets are already on v4), so gating on an exact
+ * version makes every server-side bump break the console. Semantics are read
+ * from `status` and the self-describing `fields` list instead, which keeps the
+ * fail-closed behaviour where it belongs: an unsupported capability or an
+ * unknown field is still treated as unsupported.
+ */
+const MINIMUM_CONTRACT_VERSION = 1
+
+function isSupportedContractVersion(contractVersion: number): boolean {
+  return Number.isInteger(contractVersion) && contractVersion >= MINIMUM_CONTRACT_VERSION
+}
+
 function normalizeFeature(value: unknown): RuntimeCapabilityFeature | null {
   const record = asRecord(value)
   const contractVersion = asNumber(record.contract_version)
 
-  if (contractVersion !== 1) {
+  if (!isSupportedContractVersion(contractVersion)) {
     return null
   }
 
@@ -113,7 +128,7 @@ export function normalizeRuntimeCapabilities(value: unknown): RuntimeCapabilitie
   }
 
   const storageClassesVersion = asNumber(storageClasses.contract_version)
-  if (storageClassesVersion !== 1) {
+  if (!isSupportedContractVersion(storageClassesVersion)) {
     return {
       capabilities: null,
       error: "Storage-class capabilities are unavailable on this server.",

--- a/tests/lib/runtime-capabilities.test.ts
+++ b/tests/lib/runtime-capabilities.test.ts
@@ -49,17 +49,58 @@ test("runtime capabilities normalize supported and historical replication fields
   assert.deepEqual(normalized.capabilities?.storageClasses.supportedWriteClasses, ["STANDARD", "REDUCED_REDUNDANCY"])
 })
 
-test("runtime capabilities fail closed on unknown contract versions", () => {
+test("runtime capabilities accept newer contract versions from newer servers", () => {
   const normalized = normalizeRuntimeCapabilities({
     replication: {
       contract_version: 2,
       bucket_replication: {
         contract_version: 1,
         status: { state: "supported" },
+        fields: [{ name: "Rule.ID", state: "supported" }],
+      },
+      remote_targets: {
+        // Servers have shipped remote target contract v4 (temporary credential
+        // fields promoted to writable); the console must not fail closed on a
+        // version bump it has not seen.
+        contract_version: 4,
+        status: { state: "supported" },
+        fields: [
+          { name: "credentials.sessionToken", state: "supported" },
+          { name: "edge", state: "unsupported" },
+        ],
+      },
+      mixed_version_policy: "fail_closed_when_capability_unknown_or_unsupported",
+    },
+    storage_classes: {
+      contract_version: 2,
+      supported_write_classes: ["STANDARD"],
+      unsupported_write_error: "InvalidStorageClass",
+      legacy_label_behavior: "normalized_to_effective_class",
+    },
+  })
+
+  assert.equal(normalized.error, undefined)
+  assert.equal(isRuntimeCapabilitiesSupported(normalized.capabilities), true)
+  assert.equal(getRuntimeCapabilityFieldState(normalized.capabilities, "bucketReplication", "Rule.ID"), "supported")
+  assert.equal(
+    getRuntimeCapabilityFieldState(normalized.capabilities, "remoteTargets", "credentials.sessionToken"),
+    "supported",
+  )
+  assert.equal(getRuntimeCapabilityFieldState(normalized.capabilities, "remoteTargets", "edge"), "unsupported")
+  assert.equal(getRuntimeCapabilityFieldState(normalized.capabilities, "remoteTargets", "bandwidth"), "unsupported")
+})
+
+test("runtime capabilities fail closed when a contract version is missing or invalid", () => {
+  const buildPayload = (remoteTargetsContractVersion: unknown) => ({
+    replication: {
+      contract_version: 1,
+      bucket_replication: {
+        contract_version: 1,
+        status: { state: "supported" },
         fields: [],
       },
       remote_targets: {
-        contract_version: 1,
+        contract_version: remoteTargetsContractVersion,
         status: { state: "supported" },
         fields: [],
       },
@@ -73,9 +114,38 @@ test("runtime capabilities fail closed on unknown contract versions", () => {
     },
   })
 
+  for (const invalid of [undefined, 0, -1, 1.5, "1"]) {
+    const normalized = normalizeRuntimeCapabilities(buildPayload(invalid))
+
+    assert.equal(normalized.capabilities, null)
+    assert.match(normalized.error ?? "", /unavailable/)
+    assert.equal(
+      getRuntimeCapabilityFieldState(normalized.capabilities, "remoteTargets", "disableProxy"),
+      "unsupported",
+    )
+  }
+})
+
+test("runtime capabilities fail closed when storage-class capabilities are missing", () => {
+  const normalized = normalizeRuntimeCapabilities({
+    replication: {
+      contract_version: 1,
+      bucket_replication: {
+        contract_version: 1,
+        status: { state: "supported" },
+        fields: [],
+      },
+      remote_targets: {
+        contract_version: 4,
+        status: { state: "supported" },
+        fields: [],
+      },
+      mixed_version_policy: "fail_closed_when_capability_unknown_or_unsupported",
+    },
+  })
+
   assert.equal(normalized.capabilities, null)
-  assert.match(normalized.error ?? "", /unavailable/)
-  assert.equal(getRuntimeCapabilityFieldState(normalized.capabilities, "remoteTargets", "disableProxy"), "unsupported")
+  assert.match(normalized.error ?? "", /Storage-class capabilities are unavailable/)
 })
 
 test("runtime capability fields fail closed when a feature is unavailable", () => {


### PR DESCRIPTION
# Pull Request

## Description

The bucket replication page renders **"Replication capabilities are unavailable on this server."** against current servers, and the Add / Edit / Delete rule controls are disabled — while replication itself keeps working and objects are replicated normally. The capability payload only gates console UI controls; it never reaches the replication engine.

Root cause: `normalizeRuntimeCapabilities()` rejected any capability block whose `contract_version` was not exactly `1`. The server has since bumped the remote target contract to **v4**:

| Server change | Version |
| --- | --- |
| rustfs#6376 — per-target `disableProxy` | v2 |
| rustfs#6857 / rustfs#6860 — temporary target credentials | v3 |
| rustfs#6876 — temporary-credential fields promoted to writable | v4 |

So `remote_targets` normalized to `null`, the whole snapshot was dropped, and the error alert was shown.

The contract version describes the *shape* of a capability block, which has been stable since v1. Semantics live in `status` and the self-describing `fields[].state` list, which both replication forms already read per field. This PR accepts any integer version `>= 1` and keeps the fail-closed behaviour where it belongs:

- missing, zero, negative, fractional or non-numeric `contract_version` → still rejected
- `status.state !== "supported"` → every field of that feature is still treated as unsupported
- unknown field name → still `unsupported`

The same exact-match gate on the `storage_classes` block is relaxed identically; it would have broken the same way on its next server-side bump.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Security fix

## Testing

The pre-existing "fail closed on unknown contract versions" case asserted the buggy behaviour, so it was rewritten into three cases: newer versions are accepted (using the real `remote_targets` v4 / `storage_classes` v2 shape), invalid versions still fail closed (`undefined`, `0`, `-1`, `1.5`, `"1"`), and a missing `storage_classes` block still fails closed.

Additionally verified end to end with a payload built from the server's actual v4 field lists (`crates/replication/src/config.rs`): capabilities normalize, both forms' `requiredBucketFieldsSupported` / `requiredTargetFieldsSupported` evaluate to `true`, and `edge` is still reported unsupported — i.e. `controlsLocked` becomes `false` and the rule controls are usable again.

- [x] Unit tests added/updated
- [x] Manual testing completed

```bash
node --experimental-strip-types --import ./scripts/register-typescript-loader.mjs --test tests/lib/*.test.{js,ts}   # 460 passed
tsc --noEmit          # clean
eslint                # clean
prettier --check .    # clean
```

> Note: `pnpm test:run` could not be invoked through corepack in this environment (pinned pnpm 11.11.0 vs local 11.8.0), so the underlying script commands were run directly.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

N/A — reported through manual replication testing.

## Screenshots (if applicable)

Before: the replication page showed a destructive alert titled "Replication rules unavailable" with the body "Replication capabilities are unavailable on this server.", while the site-replication rule was listed as Enabled and Add / Edit / Delete were greyed out.

## Additional Notes

No server-side change is required. This also removes the recurring maintenance trap where every server capability bump silently disables console controls until the console ships a matching release.
