### PR TITLE
fix: run Prettier in formatting CI job

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,21 +38,7 @@ jobs:
         run: pnpm ci
 
       - name: 💅 Check Prettier formatting
-        run: pnpm run lint
-
-      - name: 🔧 Auto-fix formatting (PR only)
-        if: github.event_name == 'pull_request'
-        run: |
-          pnpm run lint:fix
-          if [[ -n $(git status --porcelain) ]]; then
-            echo "## 💅 Formatting Changes Applied" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "The following files were auto-formatted:" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            git diff --name-only >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          fi
+        run: pnpm run format:check
 
   # ============================================================================
   # TypeScript 类型检查

--- a/tests/lib/quality-workflow-source.test.js
+++ b/tests/lib/quality-workflow-source.test.js
@@ -1,0 +1,12 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+
+const source = fs.readFileSync(".github/workflows/quality.yml", "utf8")
+const formattingJob = source.match(/  formatting:\n[\s\S]*?(?=\n  typescript:)/)?.[0] ?? ""
+
+test("formatting CI checks Prettier without running lint fixes", () => {
+  assert.match(formattingJob, /- name: 💅 Check Prettier formatting\n\s+run: pnpm run format:check/)
+  assert.doesNotMatch(formattingJob, /pnpm run lint/)
+  assert.doesNotMatch(formattingJob, /Auto-fix formatting/)
+})


### PR DESCRIPTION
# Pull Request

## Description

Fix the code-formatting CI job so it runs the repository's existing Prettier check instead of running ESLint.

- Run `pnpm run format:check` in the formatting job.
- Remove the PR-only lint auto-fix step, which modified only the ephemeral runner workspace and could not update the contributor branch.
- Add a regression test that keeps lint commands out of the formatting job.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing completed

```bash
pnpm install --frozen-lockfile
pnpm type-check
pnpm lint
pnpm format:check
pnpm test:run
```

All 477 tests pass.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

None.

## Screenshots (if applicable)

Not applicable; this change only affects CI configuration.

## Additional Notes

This PR intentionally keeps ESLint and Prettier and does not include the Oxlint/Oxfmt migration proposed in #217.
