### PR TITLE
fix(site-replication): identify the local site by deployment ID instead of list position

### DIFF
--- a/app/(dashboard)/site-replication/page.tsx
+++ b/app/(dashboard)/site-replication/page.tsx
@@ -35,9 +35,11 @@ import { Spinner } from "@/components/ui/spinner"
 import { useDataTable } from "@/hooks/use-data-table"
 import { usePermissions } from "@/hooks/use-permissions"
 import { useSiteReplication } from "@/hooks/use-site-replication"
+import { useSystem } from "@/hooks/use-system"
 import { formatDateTime, niceBytes } from "@/lib/functions"
 import { useDialog } from "@/lib/feedback/dialog"
 import { useMessage } from "@/lib/feedback/message"
+import { extractServerDeploymentId, resolveSiteReplicationLocalSite } from "@/lib/site-replication-local-site"
 import { isHttpsSiteReplicationEndpoint } from "@/lib/site-replication-tls"
 import type {
   SiteReplicationInfo,
@@ -117,9 +119,11 @@ export default function SiteReplicationPage() {
     resyncSiteReplication,
     setSiteReplicationIlmExpiry,
   } = useSiteReplication()
+  const { getSystemInfo } = useSystem()
 
   const [info, setInfo] = useState<SiteReplicationInfo | null>(null)
   const [status, setStatus] = useState<SiteReplicationStatus | null>(null)
+  const [serverDeploymentId, setServerDeploymentId] = useState("")
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [featureUnavailable, setFeatureUnavailable] = useState(false)
@@ -139,6 +143,14 @@ export default function SiteReplicationPage() {
     setError(null)
     setFeatureUnavailable(false)
     setStatusUnavailable(false)
+
+    // The local deployment ID is the only stable way to tell which entry of
+    // the shared, deployment-ID-sorted site list belongs to this server. Fetch
+    // it alongside the replication data; a failure here only degrades the
+    // "current site" identification, so it must not fail the whole page.
+    const serverDeploymentIdPromise = getSystemInfo(undefined, { suppress403Redirect: true })
+      .then(extractServerDeploymentId)
+      .catch(() => "")
 
     try {
       let nextInfo: SiteReplicationInfo | null = null
@@ -168,6 +180,7 @@ export default function SiteReplicationPage() {
         }
       }
 
+      setServerDeploymentId(await serverDeploymentIdPromise)
       setInfo(nextInfo)
       setStatus(nextStatus)
     } catch (loadError) {
@@ -175,7 +188,7 @@ export default function SiteReplicationPage() {
     } finally {
       setLoading(false)
     }
-  }, [getSiteReplicationInfo, getSiteReplicationStatus, t])
+  }, [getSiteReplicationInfo, getSiteReplicationStatus, getSystemInfo, t])
 
   useEffect(() => {
     void loadData()
@@ -183,10 +196,14 @@ export default function SiteReplicationPage() {
 
   const peers = info?.sites ?? []
   const ilmExpiryEnabled = peers.some((peer) => peer.replicateIlmExpiry)
-  const localDeploymentId =
-    Object.keys(status?.metrics.metrics ?? {})[0] ??
-    peers.find((peer) => peer.name && peer.name === info?.name)?.deploymentId ??
-    ""
+  // Never pick the local site by array or key position: every site returns
+  // the same list in the same order (issue rustfs/rustfs#7072).
+  const localSite = resolveSiteReplicationLocalSite({
+    serverDeploymentId,
+    localName: info?.name,
+    peers,
+  })
+  const localDeploymentId = localSite.deploymentId
   const localPeer = peers.find((peer) => peer.deploymentId === localDeploymentId) ?? null
   const localSummary = (localDeploymentId && status?.statsSummary[localDeploymentId]) || null
   const localMetric = (localDeploymentId && status?.metrics.metrics[localDeploymentId]) || null
@@ -586,6 +603,13 @@ export default function SiteReplicationPage() {
               label={t("Deployment ID")}
               value={<span className="font-mono text-xs break-all">{localDeploymentId || "--"}</span>}
             />
+            {info?.enabled && !localDeploymentId ? (
+              <p className="text-xs text-muted-foreground" role="note">
+                {localSite.ambiguousName
+                  ? t("Multiple peers share the local site name, so the current site cannot be identified.")
+                  : t("The current site could not be identified because the server did not report its deployment ID.")}
+              </p>
+            ) : null}
           </CardContent>
         </Card>
 

--- a/hooks/use-system.ts
+++ b/hooks/use-system.ts
@@ -7,8 +7,11 @@ export function useSystem() {
   const api = useApi()
 
   const getSystemInfo = useCallback(
-    async (signal?: AbortSignal) => {
-      return api.get("/info", signal ? { signal, dedupe: false } : undefined)
+    async (signal?: AbortSignal, options?: { suppress403Redirect?: boolean }) => {
+      return api.get("/info", {
+        ...(signal ? { signal, dedupe: false } : {}),
+        ...(options?.suppress403Redirect ? { suppress403Redirect: true } : {}),
+      })
     },
     [api],
   )

--- a/i18n/locales/ar-MA.json
+++ b/i18n/locales/ar-MA.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "يحتوي الملف المُصدَّر على معلومات حساسة. يرجى الحفاظ عليه بأمان.",
   "The secret key is shown only once. Copy or export it before closing.": "يتم عرض المفتاح السري مرة واحدة فقط. انسخه أو صدّره قبل الإغلاق.",
   "The server detects the local site identity from the active RustFS deployment.": "يكتشف الخادم هوية الموقع المحلي من نشر RustFS النشط.",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "تشترك عدة مواقع نظيرة في اسم الموقع المحلي نفسه، لذا يتعذر تحديد الموقع الحالي.",
+  "The current site could not be identified because the server did not report its deployment ID.": "تعذر تحديد الموقع الحالي لأن الخادم لم يُبلغ عن معرّف النشر الخاص به.",
   "The two passwords are inconsistent": "كلمتا المرور غير متطابقتين",
   "The value is used only for the initial join request.": "تُستخدم هذه القيمة فقط في طلب الانضمام الأولي.",
   "This action cannot be undone and will bypass the normal deletion process.": "لا يمكن التراجع عن هذا الإجراء وسيتجاوز عملية الحذف العادية.",

--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "Die exportierte Datei enthält sensible Informationen. Bitte bewahren Sie sie sicher auf.",
   "The secret key is shown only once. Copy or export it before closing.": "Der geheime Schlüssel wird nur einmal angezeigt. Kopieren oder exportieren Sie ihn vor dem Schließen.",
   "The server detects the local site identity from the active RustFS deployment.": "Der Server erkennt die lokale Site-Identität aus der aktiven RustFS-Bereitstellung.",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "Mehrere Peers verwenden denselben lokalen Site-Namen, daher kann die aktuelle Site nicht ermittelt werden.",
+  "The current site could not be identified because the server did not report its deployment ID.": "Die aktuelle Site konnte nicht ermittelt werden, da der Server seine Deployment-ID nicht gemeldet hat.",
   "The two passwords are inconsistent": "Die beiden Passwörter stimmen nicht überein",
   "The value is used only for the initial join request.": "Dieser Wert wird nur für die erste Beitrittsanfrage verwendet.",
   "This action cannot be undone and will bypass the normal deletion process.": "Diese Aktion kann nicht rückgängig gemacht werden und umgeht den normalen Löschprozess.",

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "The exported file contains sensitive information. Please keep it secure.",
   "The secret key is shown only once. Copy or export it before closing.": "The secret key is shown only once. Copy or export it before closing.",
   "The server detects the local site identity from the active RustFS deployment.": "The server detects the local site identity from the active RustFS deployment.",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "Multiple peers share the local site name, so the current site cannot be identified.",
+  "The current site could not be identified because the server did not report its deployment ID.": "The current site could not be identified because the server did not report its deployment ID.",
   "The two passwords are inconsistent": "The two passwords are inconsistent",
   "The value is used only for the initial join request.": "The value is used only for the initial join request.",
   "This action cannot be undone and will bypass the normal deletion process.": "This action cannot be undone and will bypass the normal deletion process.",

--- a/i18n/locales/es-ES.json
+++ b/i18n/locales/es-ES.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "El archivo exportado contiene información sensible. Manténgalo seguro.",
   "The secret key is shown only once. Copy or export it before closing.": "La clave secreta se muestra una sola vez. Cópiala o expórtala antes de cerrar.",
   "The server detects the local site identity from the active RustFS deployment.": "El servidor detecta la identidad del sitio local a partir de la implementación activa de RustFS.",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "Varios pares comparten el nombre del sitio local, por lo que no se puede identificar el sitio actual.",
+  "The current site could not be identified because the server did not report its deployment ID.": "No se pudo identificar el sitio actual porque el servidor no informó su ID de despliegue.",
   "The two passwords are inconsistent": "Las dos contraseñas no coinciden",
   "The value is used only for the initial join request.": "El valor se usa solo para la solicitud inicial de unión.",
   "This action cannot be undone and will bypass the normal deletion process.": "Esta acción no se puede deshacer y omitirá el proceso normal de eliminación.",

--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "Le fichier exporté contient des informations sensibles. Veuillez le conserver en sécurité.",
   "The secret key is shown only once. Copy or export it before closing.": "La clé secrète n’est affichée qu’une seule fois. Copiez-la ou exportez-la avant de fermer.",
   "The server detects the local site identity from the active RustFS deployment.": "Le serveur détecte l'identité du site local à partir du déploiement RustFS actif.",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "Plusieurs pairs partagent le nom du site local, le site actuel ne peut donc pas être identifié.",
+  "The current site could not be identified because the server did not report its deployment ID.": "Le site actuel n'a pas pu être identifié car le serveur n'a pas signalé son ID de déploiement.",
   "The two passwords are inconsistent": "Les deux mots de passe sont différents",
   "The value is used only for the initial join request.": "Cette valeur est utilisée uniquement pour la demande de jonction initiale.",
   "This action cannot be undone and will bypass the normal deletion process.": "Cette action ne peut pas être annulée et contournera le processus de suppression normal.",

--- a/i18n/locales/id-ID.json
+++ b/i18n/locales/id-ID.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "File yang diekspor berisi informasi sensitif. Harap jaga keamanannya.",
   "The secret key is shown only once. Copy or export it before closing.": "Kunci rahasia hanya ditampilkan sekali. Salin atau ekspor sebelum menutup.",
   "The server detects the local site identity from the active RustFS deployment.": "Server mendeteksi identitas situs lokal dari deployment RustFS yang aktif.",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "Beberapa peer menggunakan nama situs lokal yang sama, sehingga situs saat ini tidak dapat diidentifikasi.",
+  "The current site could not be identified because the server did not report its deployment ID.": "Situs saat ini tidak dapat diidentifikasi karena server tidak melaporkan deployment ID-nya.",
   "The two passwords are inconsistent": "Kedua kata sandi tidak cocok",
   "The value is used only for the initial join request.": "Nilai ini hanya digunakan untuk permintaan bergabung awal.",
   "This action cannot be undone and will bypass the normal deletion process.": "Tindakan ini tidak dapat dibatalkan dan akan melewati proses penghapusan normal.",

--- a/i18n/locales/it-IT.json
+++ b/i18n/locales/it-IT.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "Il file esportato contiene informazioni sensibili. Conservalo in modo sicuro.",
   "The secret key is shown only once. Copy or export it before closing.": "La chiave segreta viene mostrata una sola volta. Copiala o esportala prima di chiudere.",
   "The server detects the local site identity from the active RustFS deployment.": "Il server rileva l'identità del sito locale dalla distribuzione RustFS attiva.",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "Più peer condividono il nome del sito locale, quindi il sito corrente non può essere identificato.",
+  "The current site could not be identified because the server did not report its deployment ID.": "Impossibile identificare il sito corrente perché il server non ha riportato il proprio ID di deployment.",
   "The two passwords are inconsistent": "Le due password non corrispondono",
   "The value is used only for the initial join request.": "Il valore viene usato solo per la richiesta iniziale di adesione.",
   "This action cannot be undone and will bypass the normal deletion process.": "Questa azione non può essere annullata e bypasserà il normale processo di eliminazione.",

--- a/i18n/locales/ja-JP.json
+++ b/i18n/locales/ja-JP.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "エクスポートされたファイルには機密情報が含まれています。安全に保管してください。",
   "The secret key is shown only once. Copy or export it before closing.": "シークレットキーが表示されるのは一度だけです。閉じる前にコピーまたはエクスポートしてください。",
   "The server detects the local site identity from the active RustFS deployment.": "サーバーはアクティブな RustFS デプロイメントからローカルサイトの識別情報を検出します。",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "複数のピアが同じローカルサイト名を共有しているため、現在のサイトを特定できません。",
+  "The current site could not be identified because the server did not report its deployment ID.": "サーバーが deployment ID を報告しなかったため、現在のサイトを特定できません。",
   "The two passwords are inconsistent": "2つのパスワードが一致しません",
   "The value is used only for the initial join request.": "この値は初回参加リクエストでのみ使用されます。",
   "This action cannot be undone and will bypass the normal deletion process.": "この操作は元に戻せず、通常の削除プロセスをバイパスします。",

--- a/i18n/locales/ko-KR.json
+++ b/i18n/locales/ko-KR.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "내보낸 파일에 민감한 정보가 포함되어 있습니다. 안전하게 보관하세요.",
   "The secret key is shown only once. Copy or export it before closing.": "비밀 키는 한 번만 표시됩니다. 닫기 전에 복사하거나 내보내세요.",
   "The server detects the local site identity from the active RustFS deployment.": "서버는 활성 RustFS 배포에서 로컬 사이트 식별 정보를 감지합니다.",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "여러 피어가 동일한 로컬 사이트 이름을 사용하고 있어 현재 사이트를 식별할 수 없습니다.",
+  "The current site could not be identified because the server did not report its deployment ID.": "서버가 deployment ID를 보고하지 않아 현재 사이트를 식별할 수 없습니다.",
   "The two passwords are inconsistent": "두 비밀번호가 일치하지 않습니다",
   "The value is used only for the initial join request.": "이 값은 초기 참여 요청에만 사용됩니다.",
   "This action cannot be undone and will bypass the normal deletion process.": "이 작업은 실행 취소할 수 없으며 일반 삭제 프로세스를 우회합니다.",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "O arquivo exportado contém informações sensíveis. Mantenha-o seguro.",
   "The secret key is shown only once. Copy or export it before closing.": "A chave secreta é exibida apenas uma vez. Copie-a ou exporte-a antes de fechar.",
   "The server detects the local site identity from the active RustFS deployment.": "O servidor detecta a identidade do site local a partir da implantação ativa do RustFS.",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "Vários pares compartilham o nome do site local, portanto o site atual não pode ser identificado.",
+  "The current site could not be identified because the server did not report its deployment ID.": "Não foi possível identificar o site atual porque o servidor não informou seu ID de implantação.",
   "The two passwords are inconsistent": "As duas senhas são inconsistentes",
   "The value is used only for the initial join request.": "O valor é usado apenas para a solicitação inicial de ingresso.",
   "This action cannot be undone and will bypass the normal deletion process.": "Esta ação não pode ser desfeita e contornará o processo normal de exclusão.",

--- a/i18n/locales/ru-RU.json
+++ b/i18n/locales/ru-RU.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "Экспортированный файл содержит конфиденциальную информацию. Храните его в безопасности.",
   "The secret key is shown only once. Copy or export it before closing.": "Секретный ключ показывается только один раз. Скопируйте или экспортируйте его перед закрытием.",
   "The server detects the local site identity from the active RustFS deployment.": "Сервер определяет идентификатор локального сайта из активного развертывания RustFS.",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "Несколько узлов используют одно и то же имя локального сайта, поэтому текущий сайт определить невозможно.",
+  "The current site could not be identified because the server did not report its deployment ID.": "Не удалось определить текущий сайт, поскольку сервер не сообщил свой deployment ID.",
   "The two passwords are inconsistent": "Два пароля не совпадают",
   "The value is used only for the initial join request.": "Это значение используется только для первого запроса на подключение.",
   "This action cannot be undone and will bypass the normal deletion process.": "Это действие нельзя отменить, и оно обойдет обычный процесс удаления.",

--- a/i18n/locales/tr-TR.json
+++ b/i18n/locales/tr-TR.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "Dışa aktarılan dosya hassas bilgiler içerir. Lütfen güvende tutun.",
   "The secret key is shown only once. Copy or export it before closing.": "Gizli anahtar yalnızca bir kez gösterilir. Kapatmadan önce kopyalayın veya dışa aktarın.",
   "The server detects the local site identity from the active RustFS deployment.": "Sunucu, yerel site kimliğini etkin RustFS dağıtımından algılar.",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "Birden fazla eş aynı yerel site adını paylaştığından geçerli site belirlenemiyor.",
+  "The current site could not be identified because the server did not report its deployment ID.": "Sunucu deployment ID'sini bildirmediğinden geçerli site belirlenemedi.",
   "The two passwords are inconsistent": "İki şifre tutarsız",
   "The value is used only for the initial join request.": "Bu değer yalnızca ilk katılım isteği için kullanılır.",
   "This action cannot be undone and will bypass the normal deletion process.": "Bu işlem geri alınamaz ve normal silme işlemini atlayacaktır.",

--- a/i18n/locales/vi-VN.json
+++ b/i18n/locales/vi-VN.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "Tệp được xuất chứa thông tin nhạy cảm. Vui lòng bảo mật tệp này.",
   "The secret key is shown only once. Copy or export it before closing.": "Khóa bí mật chỉ được hiển thị một lần. Hãy sao chép hoặc xuất khóa trước khi đóng.",
   "The server detects the local site identity from the active RustFS deployment.": "Máy chủ phát hiện danh tính site cục bộ từ bản triển khai RustFS đang hoạt động.",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "Nhiều peer dùng chung tên site cục bộ nên không thể xác định site hiện tại.",
+  "The current site could not be identified because the server did not report its deployment ID.": "Không thể xác định site hiện tại vì máy chủ không báo cáo deployment ID của nó.",
   "The two passwords are inconsistent": "Hai mật khẩu không khớp nhau",
   "The value is used only for the initial join request.": "Giá trị này chỉ được dùng cho yêu cầu tham gia ban đầu.",
   "This action cannot be undone and will bypass the normal deletion process.": "Hành động này không thể hoàn tác và sẽ bỏ qua quy trình xóa thông thường.",

--- a/i18n/locales/zh-CN.json
+++ b/i18n/locales/zh-CN.json
@@ -1163,6 +1163,8 @@
   "The exported file contains sensitive information. Please keep it secure.": "导出的文件包含敏感信息，请妥善保管。",
   "The secret key is shown only once. Copy or export it before closing.": "Secret Key 只会显示一次，请在关闭前复制或导出。",
   "The server detects the local site identity from the active RustFS deployment.": "服务器会根据当前 RustFS 部署自动识别本地站点。",
+  "Multiple peers share the local site name, so the current site cannot be identified.": "多个站点使用了相同的本地站点名称，无法识别当前站点。",
+  "The current site could not be identified because the server did not report its deployment ID.": "服务器未上报其 deployment ID，无法识别当前站点。",
   "The two passwords are inconsistent": "两个密码不一致",
   "The value is used only for the initial join request.": "该值仅用于初次加入请求。",
   "This action cannot be undone and will bypass the normal deletion process.": "此操作无法撤销，将绕过正常删除过程。",

--- a/lib/site-replication-local-site.ts
+++ b/lib/site-replication-local-site.ts
@@ -1,0 +1,71 @@
+type JsonRecord = Record<string, unknown>
+
+export type SiteReplicationLocalSiteSource = "server" | "name" | "none"
+
+export interface SiteReplicationLocalSiteCandidate {
+  name: string
+  deploymentId: string
+}
+
+export interface SiteReplicationLocalSiteResolution {
+  /** Deployment ID of the local site, or "" when it cannot be determined. */
+  deploymentId: string
+  /** Which evidence produced the answer. */
+  source: SiteReplicationLocalSiteSource
+  /** True when the only evidence is a site name shared by several peers. */
+  ambiguousName: boolean
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {}
+}
+
+function asTrimmedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+/**
+ * Read the local deployment ID from an admin `/info` response. The server
+ * wraps the payload as `{ info: { deploymentID } }`, but accept a bare
+ * `InfoMessage` as well so callers can pass either shape.
+ */
+export function extractServerDeploymentId(value: unknown): string {
+  const record = asRecord(value)
+  const wrapped = asRecord(record.info ?? record.Info)
+  const source = Object.keys(wrapped).length > 0 ? wrapped : record
+
+  return asTrimmedString(source.deploymentID ?? source.deploymentId ?? source.DeploymentID)
+}
+
+/**
+ * Identify the local site of a site replication group.
+ *
+ * Every site returns the same `sites` list and the same metrics map, both
+ * sorted by deployment ID, so array or key position can never tell which
+ * entry is local. The local deployment ID reported by the server itself is
+ * the only stable identity; the top-level site name is a fallback that is
+ * only trusted when exactly one peer carries it, because the backend does
+ * not enforce unique site names.
+ */
+export function resolveSiteReplicationLocalSite(input: {
+  serverDeploymentId?: string | null
+  localName?: string | null
+  peers: readonly SiteReplicationLocalSiteCandidate[]
+}): SiteReplicationLocalSiteResolution {
+  const serverDeploymentId = asTrimmedString(input.serverDeploymentId)
+  if (serverDeploymentId) {
+    return { deploymentId: serverDeploymentId, source: "server", ambiguousName: false }
+  }
+
+  const localName = asTrimmedString(input.localName)
+  if (!localName) {
+    return { deploymentId: "", source: "none", ambiguousName: false }
+  }
+
+  const matches = input.peers.filter((peer) => peer.name.trim() === localName && peer.deploymentId.trim())
+  if (matches.length === 1) {
+    return { deploymentId: matches[0].deploymentId.trim(), source: "name", ambiguousName: false }
+  }
+
+  return { deploymentId: "", source: "none", ambiguousName: matches.length > 1 }
+}

--- a/tests/lib/site-replication-local-site.test.js
+++ b/tests/lib/site-replication-local-site.test.js
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { readFile } from "node:fs/promises"
+
+const loadHelpers = () => import(new URL("../../lib/site-replication-local-site.ts", import.meta.url).href)
+
+// Both sites return the same list, sorted by deployment ID (issue #7072).
+const SHARED_SITES = [
+  { name: "site-b", deploymentId: "deployment-a-peer" },
+  { name: "site-a", deploymentId: "deployment-b-local" },
+]
+
+test("local site is taken from the server deployment ID, not list position", async () => {
+  const { resolveSiteReplicationLocalSite } = await loadHelpers()
+
+  const onSiteA = resolveSiteReplicationLocalSite({
+    serverDeploymentId: "deployment-b-local",
+    localName: "site-a",
+    peers: SHARED_SITES,
+  })
+  assert.deepEqual(onSiteA, { deploymentId: "deployment-b-local", source: "server", ambiguousName: false })
+
+  const onSiteB = resolveSiteReplicationLocalSite({
+    serverDeploymentId: "deployment-a-peer",
+    localName: "site-b",
+    peers: SHARED_SITES,
+  })
+  assert.deepEqual(onSiteB, { deploymentId: "deployment-a-peer", source: "server", ambiguousName: false })
+})
+
+test("local site falls back to a unique site name match when the server ID is unavailable", async () => {
+  const { resolveSiteReplicationLocalSite } = await loadHelpers()
+
+  const resolved = resolveSiteReplicationLocalSite({
+    serverDeploymentId: "",
+    localName: " site-a ",
+    peers: SHARED_SITES,
+  })
+  assert.deepEqual(resolved, { deploymentId: "deployment-b-local", source: "name", ambiguousName: false })
+})
+
+test("local site stays unresolved instead of guessing when names are missing or duplicated", async () => {
+  const { resolveSiteReplicationLocalSite } = await loadHelpers()
+
+  const duplicated = resolveSiteReplicationLocalSite({
+    serverDeploymentId: null,
+    localName: "shared",
+    peers: [
+      { name: "shared", deploymentId: "deployment-1" },
+      { name: "shared", deploymentId: "deployment-2" },
+    ],
+  })
+  assert.deepEqual(duplicated, { deploymentId: "", source: "none", ambiguousName: true })
+
+  const missing = resolveSiteReplicationLocalSite({
+    serverDeploymentId: undefined,
+    localName: "",
+    peers: SHARED_SITES,
+  })
+  assert.deepEqual(missing, { deploymentId: "", source: "none", ambiguousName: false })
+
+  const unknownName = resolveSiteReplicationLocalSite({
+    serverDeploymentId: undefined,
+    localName: "site-c",
+    peers: SHARED_SITES,
+  })
+  assert.deepEqual(unknownName, { deploymentId: "", source: "none", ambiguousName: false })
+})
+
+test("server deployment ID is read from wrapped and bare admin info payloads", async () => {
+  const { extractServerDeploymentId } = await loadHelpers()
+
+  assert.equal(extractServerDeploymentId({ info: { deploymentID: " deployment-b-local " } }), "deployment-b-local")
+  assert.equal(extractServerDeploymentId({ deploymentID: "deployment-a-peer" }), "deployment-a-peer")
+  assert.equal(extractServerDeploymentId({ info: {} }), "")
+  assert.equal(extractServerDeploymentId(null), "")
+  assert.equal(extractServerDeploymentId("deployment-x"), "")
+})
+
+test("site replication overview no longer picks the local site by position", async () => {
+  const source = await readFile(new URL("../../app/(dashboard)/site-replication/page.tsx", import.meta.url), "utf8")
+
+  assert.match(source, /resolveSiteReplicationLocalSite/)
+  assert.doesNotMatch(source, /Object\.keys\(status\?\.metrics\.metrics \?\? \{\}\)\[0\]/)
+  assert.doesNotMatch(source, /sites\[0\]/)
+})


### PR DESCRIPTION
# Pull Request

## Description

The Site Replication page identified the "current site" by taking the first key of the status `replMetrics` map (the name-match fallback after it was unreachable because `??` never fires on a string). Since rustfs/rustfs#7024 (shipped in `1.0.0-rc.5`) the server emits a metrics entry for **every** peer, and both `sites` and `replMetrics` come from `BTreeMap`s keyed by deployment ID, so every site returns the same list in the same order. On the site whose deployment ID sorts later, the Current Site card showed the local name together with the peer's endpoint and deployment ID, and the peer table marked the wrong row as current.

This PR:

- Adds `lib/site-replication-local-site.ts` with `resolveSiteReplicationLocalSite`, which resolves the local site from the deployment ID reported by `/admin/v3/info` first, falls back to the top-level site name only when exactly one peer carries it (the backend does not enforce unique site names), and never picks by array or key position.
- Loads `/info` alongside the replication data in `app/(dashboard)/site-replication/page.tsx` (best-effort, failures only degrade identification) and drives the Current Site card, the "Current Site" badge, and the local stats from the resolved ID. When no identity can be established the card explains why (duplicate names vs. missing deployment ID) instead of showing peer data.
- Lets `getSystemInfo` in `hooks/use-system.ts` accept `suppress403Redirect` so the auxiliary `/info` call cannot trigger the global 403 handler for users without `ServerInfo` permission.
- Adds the two new notice strings to all 14 locale files.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

```bash
pnpm test:run
```

- `tests/lib/site-replication-local-site.test.js` covers: server ID wins regardless of list order (both sites of the same shared list), unique-name fallback, no guessing on missing/duplicate/unknown names, `/info` payload extraction (wrapped and bare), and a source assertion that the page no longer uses `Object.keys(...)[0]` / `sites[0]`.
- `pnpm run test:run` (482 pass), `pnpm run type-check`, `eslint` and `prettier --check` on the changed files and all locale JSON all pass.
- End-to-end against a local two-site RustFS lab built from current `rustfs` main (`scripts/test/site_replication_smoke.py`): fed the live `/info`, `site-replication/info` and `site-replication/status` responses of both sites to the resolver. The old first-key logic picks the wrong site on `site-b`; the new resolver is correct on both sites via the server deployment ID.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

Closes rustfs/rustfs#7072

## Screenshots (if applicable)

N/A. The UI text only changes in the unresolved case (a muted note under the Deployment ID field).

## Additional Notes

- Reviewer note: the fix works with existing servers because `/admin/v3/info` already returns `deploymentID`. A follow-up on the server side could add a top-level local `deploymentID` to `SiteReplicationInfo` so the console does not need the cross-endpoint lookup; that is optional and not required for this fix.
