### PR TITLE
feat: add login secret visibility toggle

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -1,13 +1,15 @@
 "use client"
 
+import { useState } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { useTranslation } from "react-i18next"
-import { RiSettings3Line } from "@remixicon/react"
+import { RiEyeLine, RiEyeOffLine, RiSettings3Line } from "@remixicon/react"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Field, FieldContent, FieldError, FieldLabel } from "@/components/ui/field"
+import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from "@/components/ui/input-group"
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp"
 import { Spinner } from "@/components/ui/spinner"
 import { TOTP_CODE_LENGTH } from "@/lib/mfa"
@@ -57,6 +59,38 @@ export interface LoginFormProps {
   onOidcLogin?: (providerId: string) => void
   /** Present only while the server is waiting for a second factor. */
   secondFactor?: SecondFactorStep
+}
+
+type SecretKeyInputProps = Omit<React.ComponentProps<typeof InputGroupInput>, "className" | "type">
+
+function SecretKeyInput({ id, ...props }: SecretKeyInputProps) {
+  const { t } = useTranslation()
+  const [visible, setVisible] = useState(false)
+  const visibilityLabel = visible ? t("Hide key") : t("Show key")
+
+  return (
+    <InputGroup className="h-11 sm:h-8">
+      <InputGroupInput
+        {...props}
+        id={id}
+        type={visible ? "text" : "password"}
+        className="h-11 text-base sm:h-8 sm:text-xs"
+      />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton
+          type="button"
+          size="icon-xs"
+          className="size-11 sm:size-6"
+          aria-label={visibilityLabel}
+          aria-controls={id}
+          title={visibilityLabel}
+          onClick={() => setVisible((current) => !current)}
+        >
+          {visible ? <RiEyeOffLine aria-hidden /> : <RiEyeLine aria-hidden />}
+        </InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  )
 }
 
 export function LoginForm({
@@ -222,7 +256,8 @@ export function LoginForm({
                           <Field>
                             <FieldLabel htmlFor="secretKey">{t("Key")}</FieldLabel>
                             <FieldContent>
-                              <Input
+                              <SecretKeyInput
+                                key="access-key-secret"
                                 id="secretKey"
                                 name="secretKey"
                                 value={accessKeyAndSecretKey.secretAccessKey}
@@ -233,10 +268,8 @@ export function LoginForm({
                                   }))
                                 }
                                 autoComplete="current-password"
-                                type="password"
                                 spellCheck={false}
                                 required
-                                className="h-11 text-base sm:h-8 sm:text-xs"
                                 placeholder={t("Please enter key")}
                               />
                             </FieldContent>
@@ -269,7 +302,8 @@ export function LoginForm({
                           <Field>
                             <FieldLabel htmlFor="stsSecretKey">{t("STS Key")}</FieldLabel>
                             <FieldContent>
-                              <Input
+                              <SecretKeyInput
+                                key="sts-secret"
                                 id="stsSecretKey"
                                 name="stsSecretKey"
                                 value={sts.secretAccessKey}
@@ -280,10 +314,8 @@ export function LoginForm({
                                   }))
                                 }
                                 autoComplete="new-password"
-                                type="password"
                                 spellCheck={false}
                                 required
-                                className="h-11 text-base sm:h-8 sm:text-xs"
                                 placeholder={t("Please enter STS key")}
                               />
                             </FieldContent>

--- a/i18n/locales/ar-MA.json
+++ b/i18n/locales/ar-MA.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "تغيّر المصدر بعد النسخ.",
   "Source deletion could not be confirmed.": "تعذّر تأكيد حذف المصدر.",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "تم نسخ الكائن إلى الوجهة، لكن تعذّر تأكيد حذف المصدر. تحقّق من الموقعين قبل إعادة المحاولة.",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "تغيّر المصدر أو أن الوجهة موجودة بالفعل. حدّث الصفحة واختر وجهة أخرى."
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "تغيّر المصدر أو أن الوجهة موجودة بالفعل. حدّث الصفحة واختر وجهة أخرى.",
+  "Show key": "إظهار المفتاح",
+  "Hide key": "إخفاء المفتاح"
 }

--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "Die Quelle wurde nach dem Kopieren geändert.",
   "Source deletion could not be confirmed.": "Das Löschen der Quelle konnte nicht bestätigt werden.",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "Das Objekt wurde an das Ziel kopiert, aber das Löschen der Quelle konnte nicht bestätigt werden. Prüfen Sie beide Speicherorte, bevor Sie es erneut versuchen.",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "Die Quelle wurde geändert oder das Ziel ist bereits vorhanden. Aktualisieren Sie die Ansicht und wählen Sie ein anderes Ziel."
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "Die Quelle wurde geändert oder das Ziel ist bereits vorhanden. Aktualisieren Sie die Ansicht und wählen Sie ein anderes Ziel.",
+  "Show key": "Schlüssel anzeigen",
+  "Hide key": "Schlüssel ausblenden"
 }

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "The source changed after copying.",
   "Source deletion could not be confirmed.": "Source deletion could not be confirmed.",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "The source changed or the destination already exists. Refresh and choose a different destination."
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "The source changed or the destination already exists. Refresh and choose a different destination.",
+  "Show key": "Show key",
+  "Hide key": "Hide key"
 }

--- a/i18n/locales/es-ES.json
+++ b/i18n/locales/es-ES.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "El origen cambió después de la copia.",
   "Source deletion could not be confirmed.": "No se pudo confirmar la eliminación del origen.",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "El objeto se ha copiado al destino, pero no se pudo confirmar la eliminación del origen. Compruebe ambas ubicaciones antes de volver a intentarlo.",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "El origen ha cambiado o el destino ya existe. Actualice y elija otro destino."
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "El origen ha cambiado o el destino ya existe. Actualice y elija otro destino.",
+  "Show key": "Mostrar clave",
+  "Hide key": "Ocultar clave"
 }

--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "La source a été modifiée après la copie.",
   "Source deletion could not be confirmed.": "La suppression de la source n’a pas pu être confirmée.",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "L’objet a été copié vers la destination, mais la suppression de la source n’a pas pu être confirmée. Vérifiez les deux emplacements avant de réessayer.",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "La source a changé ou la destination existe déjà. Actualisez et choisissez une autre destination."
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "La source a changé ou la destination existe déjà. Actualisez et choisissez une autre destination.",
+  "Show key": "Afficher la clé",
+  "Hide key": "Masquer la clé"
 }

--- a/i18n/locales/id-ID.json
+++ b/i18n/locales/id-ID.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "Sumber berubah setelah disalin.",
   "Source deletion could not be confirmed.": "Penghapusan sumber tidak dapat dikonfirmasi.",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "Objek telah disalin ke tujuan, tetapi penghapusan sumber tidak dapat dikonfirmasi. Periksa kedua lokasi sebelum mencoba lagi.",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "Sumber berubah atau tujuan sudah ada. Muat ulang dan pilih tujuan lain."
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "Sumber berubah atau tujuan sudah ada. Muat ulang dan pilih tujuan lain.",
+  "Show key": "Tampilkan kunci",
+  "Hide key": "Sembunyikan kunci"
 }

--- a/i18n/locales/it-IT.json
+++ b/i18n/locales/it-IT.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "L’origine è stata modificata dopo la copia.",
   "Source deletion could not be confirmed.": "Non è stato possibile confermare l’eliminazione dell’origine.",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "L’oggetto è stato copiato nella destinazione, ma non è stato possibile confermare l’eliminazione dell’origine. Controlla entrambe le posizioni prima di riprovare.",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "L’origine è cambiata o la destinazione esiste già. Aggiorna e scegli un’altra destinazione."
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "L’origine è cambiata o la destinazione esiste già. Aggiorna e scegli un’altra destinazione.",
+  "Show key": "Mostra chiave",
+  "Hide key": "Nascondi chiave"
 }

--- a/i18n/locales/ja-JP.json
+++ b/i18n/locales/ja-JP.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "コピー後に元のオブジェクトが変更されました。",
   "Source deletion could not be confirmed.": "元のオブジェクトの削除を確認できませんでした。",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "宛先へのコピーは完了しましたが、元のオブジェクトの削除を確認できませんでした。再試行する前に両方の場所を確認してください。",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "元のオブジェクトが変更されたか、宛先にオブジェクトが既に存在します。更新して別の宛先を選択してください。"
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "元のオブジェクトが変更されたか、宛先にオブジェクトが既に存在します。更新して別の宛先を選択してください。",
+  "Show key": "キーを表示",
+  "Hide key": "キーを隠す"
 }

--- a/i18n/locales/ko-KR.json
+++ b/i18n/locales/ko-KR.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "복사 후 원본 객체가 변경되었습니다.",
   "Source deletion could not be confirmed.": "원본 객체가 삭제되었는지 확인할 수 없습니다.",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "대상 위치에 복사했지만 원본 객체가 삭제되었는지 확인할 수 없습니다. 다시 시도하기 전에 두 위치를 모두 확인하세요.",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "원본 객체가 변경되었거나 대상 객체가 이미 존재합니다. 새로 고친 후 다른 대상 위치를 선택하세요."
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "원본 객체가 변경되었거나 대상 객체가 이미 존재합니다. 새로 고친 후 다른 대상 위치를 선택하세요.",
+  "Show key": "키 표시",
+  "Hide key": "키 숨기기"
 }

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "A origem foi alterada após a cópia.",
   "Source deletion could not be confirmed.": "Não foi possível confirmar a exclusão da origem.",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "O objeto foi copiado para o destino, mas não foi possível confirmar a exclusão da origem. Verifique os dois locais antes de tentar novamente.",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "A origem foi alterada ou o destino já existe. Atualize e escolha outro destino."
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "A origem foi alterada ou o destino já existe. Atualize e escolha outro destino.",
+  "Show key": "Mostrar chave",
+  "Hide key": "Ocultar chave"
 }

--- a/i18n/locales/ru-RU.json
+++ b/i18n/locales/ru-RU.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "Исходный объект изменился после копирования.",
   "Source deletion could not be confirmed.": "Не удалось подтвердить удаление исходного объекта.",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "Объект скопирован в место назначения, но удаление исходного объекта не подтверждено. Проверьте оба места перед повторной попыткой.",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "Исходный объект изменился или целевой объект уже существует. Обновите данные и выберите другое место назначения."
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "Исходный объект изменился или целевой объект уже существует. Обновите данные и выберите другое место назначения.",
+  "Show key": "Показать ключ",
+  "Hide key": "Скрыть ключ"
 }

--- a/i18n/locales/tr-TR.json
+++ b/i18n/locales/tr-TR.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "Kaynak, kopyalamadan sonra değişti.",
   "Source deletion could not be confirmed.": "Kaynağın silindiği doğrulanamadı.",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "Nesne hedefe kopyalandı ancak kaynağın silindiği doğrulanamadı. Yeniden denemeden önce her iki konumu da kontrol edin.",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "Kaynak değişti veya hedef zaten mevcut. Yenileyin ve farklı bir hedef seçin."
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "Kaynak değişti veya hedef zaten mevcut. Yenileyin ve farklı bir hedef seçin.",
+  "Show key": "Anahtarı göster",
+  "Hide key": "Anahtarı gizle"
 }

--- a/i18n/locales/vi-VN.json
+++ b/i18n/locales/vi-VN.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "Đối tượng nguồn đã thay đổi sau khi sao chép.",
   "Source deletion could not be confirmed.": "Không thể xác nhận việc xóa đối tượng nguồn.",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "Đã sao chép đối tượng đến đích nhưng không thể xác nhận việc xóa đối tượng nguồn. Hãy kiểm tra cả hai vị trí trước khi thử lại.",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "Đối tượng nguồn đã thay đổi hoặc đích đã tồn tại. Hãy làm mới và chọn đích khác."
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "Đối tượng nguồn đã thay đổi hoặc đích đã tồn tại. Hãy làm mới và chọn đích khác.",
+  "Show key": "Hiện khóa",
+  "Hide key": "Ẩn khóa"
 }

--- a/i18n/locales/zh-CN.json
+++ b/i18n/locales/zh-CN.json
@@ -1964,5 +1964,7 @@
   "The source changed after copying.": "源对象在复制后发生了变化。",
   "Source deletion could not be confirmed.": "无法确认源对象是否已删除。",
   "The destination was copied, but source deletion could not be confirmed. Check both locations before retrying.": "对象已复制到目标位置，但无法确认源对象是否已删除。请检查源位置和目标位置后再重试。",
-  "The source changed or the destination already exists. Refresh and choose a different destination.": "源对象已发生变化，或目标对象已存在。请刷新后选择其他目标位置。"
+  "The source changed or the destination already exists. Refresh and choose a different destination.": "源对象已发生变化，或目标对象已存在。请刷新后选择其他目标位置。",
+  "Show key": "显示密钥",
+  "Hide key": "隐藏密钥"
 }

--- a/tests/lib/ui-layout-source.test.js
+++ b/tests/lib/ui-layout-source.test.js
@@ -19,6 +19,16 @@ test("auth surfaces use dynamic viewport height and mobile touch targets", () =>
   assert.doesNotMatch(login, /lg:w-7\/12/)
 })
 
+test("login secret fields provide accessible reveal controls", () => {
+  const login = fs.readFileSync("components/auth/login-form.tsx", "utf8")
+  const secretFields = login.match(/<SecretKeyInput/g) ?? []
+
+  assert.equal(secretFields.length, 2)
+  assert.match(login, /type=\{visible \? "text" : "password"\}/)
+  assert.match(login, /const visibilityLabel = visible \? t\("Hide key"\) : t\("Show key"\)/)
+  assert.match(login, /<InputGroupButton[\s\S]*?type="button"[\s\S]*?aria-label=\{visibilityLabel\}/)
+})
+
 test("status toolbars keep mobile touch targets without stretching desktop controls", () => {
   const page = fs.readFileSync("app/(dashboard)/status/page.tsx", "utf8")
   const servers = fs.readFileSync("app/(dashboard)/_components/performance-server-list.tsx", "utf8")


### PR DESCRIPTION
# Pull Request

## Description

- Add an eye control to reveal or mask the key-login secret.
- Apply the same interaction to the STS secret field and reset visibility when switching login methods.
- Provide localized, accessible show/hide labels for every bundled locale.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

```bash
pnpm install --frozen-lockfile
pnpm type-check
pnpm lint
pnpm format:check
pnpm test:run
```

All 483 tests pass. The reveal control was exercised in both key-login and STS modes at desktop and mobile viewports.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

N/A

## Screenshots (if applicable)

### Before

![Login form before the secret visibility control](https://github.com/user-attachments/assets/19014873-af1f-4483-9f43-786f39a28c97)

### After

![Login form with the secret revealed using the visibility control](https://github.com/user-attachments/assets/b57974c7-b643-4dd5-82be-6a804c80b69b)

## Additional Notes

The secret remains masked by default, and switching login methods restores the masked state.
