### PR TITLE
fix: consolidate S3 Tables refresh controls

### DIFF
--- a/app/(dashboard)/table-catalog/page.tsx
+++ b/app/(dashboard)/table-catalog/page.tsx
@@ -290,9 +290,7 @@ export default function TableCatalogPage() {
       hasLoadedRef.current = true
       setInitializing(false)
       setRefreshing(false)
-      if (bucketResult.status === "fulfilled") {
-        void loadBucketStatuses(names, requestId, !isInitial, nextCatalogPrefix)
-      }
+      void loadBucketStatuses(names, requestId, !isInitial, nextCatalogPrefix)
     },
     [getCatalogConfig, listBuckets, loadBucketStatuses, t],
   )
@@ -927,15 +925,6 @@ export default function TableCatalogPage() {
               ) : selectedInfo ? (
                 <Badge variant="outline">{t("Not enabled")}</Badge>
               ) : null}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => void refreshWorkspace()}
-                disabled={!selectedBucket || bucketStatusLoading[selectedBucket]}
-              >
-                <RiRefreshLine className="size-4" aria-hidden />
-                {t("Refresh")}
-              </Button>
               {selectedInfo?.enabled && activeTab === "tables" ? (
                 <Button
                   variant="default"


### PR DESCRIPTION
# Pull Request

## Description

S3 Tables displayed two Refresh buttons with overlapping scopes. Keep the page-header Refresh as the single normal refresh action and remove the warehouse toolbar duplicate. Context-specific Retry actions remain available.

Continue refreshing known buckets when listing S3 buckets fails, while retaining the listing error. This preserves the ability to update the current catalog after removing the independent warehouse refresh action.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Security fix

## Testing

- [ ] Unit tests added/updated: N/A; this page interaction was verified with an isolated browser fixture, and all 563 existing tests pass.
- [x] Manual testing completed: before/after screenshots inspected at desktop and mobile sizes and in dark mode.

```bash
nvm use v22
pnpm install --frozen-lockfile
pnpm type-check
pnpm lint
pnpm format:check
pnpm test:run
git diff --check
```

Browser checks against the local Next.js app with intercepted API responses verified:

- One normal Refresh action remains at desktop (1440 × 1000), mobile (390 × 844), and dark-mode layouts, without horizontal page overflow.
- Header Refresh reloads catalog configuration, the bucket list and statuses, namespaces, tables, and views, and displays updated results.
- A failed bucket-status request retains its local Retry, which restores the workspace.
- A failed S3 bucket-list request still refreshes known bucket statuses and catalog contents, keeps the error visible, and recovers through Retry.
- No unexpected API requests or browser errors in the successful flows.

No live backend data was modified. A production build was not run locally; type checking and the running page cover this bounded change, and CI runs the production build.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

N/A

## Screenshots (if applicable)

Captured from the actual local page with illustrative fixture data. Before and after use the same viewport and catalog state; these screenshots do not represent live-backend validation.

| View | Before | After |
| --- | --- | --- |
| Desktop | ![Desktop before](https://github.com/user-attachments/assets/dd1554f0-5658-4560-82a6-bb4b174b7627) | ![Desktop after](https://github.com/user-attachments/assets/96cafeac-5bf4-4d4e-97cd-f19faecafcdf) |

## Additional Notes

Independent correctness, simplicity, and UX review completed. The only additional requests occur when a bucket-list refresh fails after buckets were previously loaded: their statuses are still queried, with existing permission and error handling intact.
