### PR TITLE
fix: respect the configured console base path in API requests

### DIFF
--- a/lib/config-helpers.ts
+++ b/lib/config-helpers.ts
@@ -34,10 +34,11 @@ const CREDENTIALS_KEY = "auth.credentials"
 const PERMANENT_CREDENTIALS_KEY = "auth.permanent"
 const DEFAULT_REGION = "us-east-1"
 const API_PATH = "/rustfs/admin/v3"
-const VERSION_PATH = "/rustfs/console/version"
+const CONSOLE_BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "/rustfs/console"
+const VERSION_PATH = `${CONSOLE_BASE_PATH}/version`
 const REQUEST_TIMEOUT = 5000
 const HEALTH_REQUEST_TIMEOUT = 5000
-const HEALTH_PATHS = ["/rustfs/console/health", "/health"] as const
+const HEALTH_PATHS = [`${CONSOLE_BASE_PATH}/health`, "/health"] as const
 
 const getApiPrefix = (): string => (process.env.NEXT_PUBLIC_API_PREFIX || "").replace(/\/$/, "")
 

--- a/tests/lib/console-base-path.test.ts
+++ b/tests/lib/console-base-path.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test"
+import type { TestContext } from "node:test"
+import assert from "node:assert/strict"
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { execFileSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import { AwsClient } from "../../lib/aws4fetch"
+import { checkServerHealth, fetchVersionConfigFromServer } from "../../lib/config-helpers"
+import { getLoginRoute } from "../../lib/routes"
+
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "/rustfs/console"
+const serverHost = "https://console.example.com"
+
+function stubGlobal(t: TestContext, name: string, value: unknown) {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, name)
+  Object.defineProperty(globalThis, name, { configurable: true, value })
+  t.after(() => {
+    if (previous) Object.defineProperty(globalThis, name, previous)
+    else Reflect.deleteProperty(globalThis, name)
+  })
+}
+
+test("console health checks use the configured base path", async (t) => {
+  const fetchMock = t.mock.method(globalThis, "fetch", async () => new Response(null, { status: 200 }))
+
+  const result = await checkServerHealth(serverHost)
+
+  assert.equal(result.url, `${serverHost}${basePath}/health`)
+  assert.equal(fetchMock.mock.calls[0].arguments[0], result.url)
+  assert.equal(fetchMock.mock.calls[0].arguments[1]?.method, "HEAD")
+})
+
+test("console health checks retain the root health fallback", async (t) => {
+  const requests: string[] = []
+  t.mock.method(globalThis, "fetch", async (input: unknown) => {
+    requests.push(String(input))
+    return new Response(null, { status: requests.length === 1 ? 404 : 200 })
+  })
+
+  const result = await checkServerHealth(serverHost)
+
+  assert.equal(result.healthy, true)
+  assert.deepEqual(requests, [`${serverHost}${basePath}/health`, `${serverHost}/health`])
+})
+
+test("console version requests use the configured base path", async (t) => {
+  stubGlobal(t, "window", {})
+  stubGlobal(t, "localStorage", {
+    getItem: (key: string) =>
+      key === "auth.permanent" ? JSON.stringify({ AccessKeyId: "test-access", SecretAccessKey: "test-secret" }) : null,
+  })
+  const fetchMock = t.mock.method(AwsClient.prototype, "fetch", async () => Response.json({ version: "test" }))
+
+  assert.deepEqual(await fetchVersionConfigFromServer(serverHost), { version: "test" })
+  assert.equal(fetchMock.mock.calls[0].arguments[0], `${serverHost}${basePath}/version`)
+})
+
+test("console login links retain the configured base path", (t) => {
+  stubGlobal(t, "window", { location: { pathname: `${basePath}/buckets/` } })
+  assert.equal(getLoginRoute(), `${basePath}/auth/login`)
+})
+
+test("static export preparation puts assets under the configured base path", (t) => {
+  const directory = mkdtempSync(join(tmpdir(), "console-base-path-"))
+  t.after(() => rmSync(directory, { recursive: true, force: true }))
+  mkdirSync(join(directory, "out", "_next"), { recursive: true })
+  writeFileSync(join(directory, "out", "index.html"), "<html>console</html>")
+  writeFileSync(join(directory, "out", "_next", "app.js"), "console.log('asset')")
+
+  execFileSync(
+    process.execPath,
+    [fileURLToPath(new URL("../../scripts/prepare-static-basepath.js", import.meta.url))],
+    {
+      cwd: directory,
+      env: { ...process.env, NEXT_PUBLIC_BASE_PATH: basePath },
+    },
+  )
+
+  const exportedPath = join(directory, "out", basePath.slice(1))
+  assert.equal(readFileSync(join(exportedPath, "index.html"), "utf8"), "<html>console</html>")
+  assert.equal(readFileSync(join(exportedPath, "_next", "app.js"), "utf8"), "console.log('asset')")
+})


### PR DESCRIPTION
# Pull Request

## Description

When the console is built with a custom `NEXT_PUBLIC_BASE_PATH`, health and version requests still target `/rustfs/console`. Derive both endpoints from the configured base path so they match the exported pages and server routes. Unset or empty values retain `/rustfs/console`, and the root `/health` fallback remains available.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

Validated the source diff in `4fe0688ae8f996042857b913985f9a84869a7484`, based on `a2f33b12acc1be9887c39cba8a73a8943baee690`, with Node 22:

```bash
pnpm install --frozen-lockfile
pnpm type-check
pnpm lint
pnpm format:check
pnpm test:run
NEXT_PUBLIC_BASE_PATH=/nuofans/console node --experimental-strip-types --import ./scripts/register-typescript-loader.mjs --test tests/lib/console-base-path.test.ts
```

All checks passed: 568 tests in the complete suite and 5 tests with the custom prefix. The focused tests cover health requests, the root health fallback, version requests, login links, and static export placement. Production builds of the same source with the example theme passed for both the default and custom paths; custom pages and JavaScript assets were also served successfully by a matching local RustFS build.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

No linked issue. Companion server build-time prefix support: https://github.com/rustfs/rustfs/pull/7636.

## Screenshots (if applicable)

N/A: this changes endpoint URL construction and adds regression tests; there are no page layout, styling, or component changes.

## Additional Notes

The base path is fixed during the Next.js build. The server must expose the same prefix, and changing the deployed runtime environment does not rewrite an existing static export. Roll back by rebuilding the console and server with their default prefixes.
