### PR TITLE
fix(browser): preserve S3 object deletion semantics

### DIFF
--- a/components/object/list.tsx
+++ b/components/object/list.tsx
@@ -63,7 +63,7 @@ import {
 import { OBJECT_LIST_DEFAULT_PAGE_SIZE, resolveObjectListPageSize } from "@/lib/object-list-pagination"
 import {
   resolveBucketVersioningState,
-  shouldForceDeleteObjects,
+  shouldDeleteAllVersions,
   shouldShowDeleteAllVersions,
   type BucketVersioningState,
 } from "@/lib/object-delete"
@@ -715,7 +715,7 @@ export function ObjectList({
     setDeleteDialogOpen(false)
     if (!keys.length) return
 
-    if (shouldForceDeleteObjects(bucketVersioningState, deleteAllVersions)) {
+    if (shouldDeleteAllVersions(bucketVersioningState, deleteAllVersions)) {
       await handleDeleteAllVersions(keys)
     } else {
       await handleDelete(keys)
@@ -767,7 +767,7 @@ export function ObjectList({
       }
 
       if (objectKeys.length > 0) {
-        addDeleteKeys(objectKeys, bucket, undefined, { forceDelete: true })
+        addDeleteKeys(objectKeys, bucket, undefined, { deleteAllVersions: true })
       }
       for (const prefix of folderPrefixes) {
         addDeleteFolder(prefix, bucket, { forceDelete: true })

--- a/contexts/task-context.tsx
+++ b/contexts/task-context.tsx
@@ -24,7 +24,12 @@ const emptyManager: TaskManagerApi<AnyTask> = {
 const TaskContext = React.createContext<{
   taskManager: TaskManagerApi<AnyTask>
   addUploadFiles: (items: { file: File; key: string }[], bucketName: string) => void
-  addDeleteKeys: (keys: string[], bucketName: string, prefix?: string, options?: { forceDelete?: boolean }) => void
+  addDeleteKeys: (
+    keys: string[],
+    bucketName: string,
+    prefix?: string,
+    options?: { deleteAllVersions?: boolean },
+  ) => void
   addDeleteFolder: (prefix: string, bucketName: string, options?: { forceDelete?: boolean }) => void
   isTaskPanelOpen: boolean
   setTaskPanelOpen: (open: boolean) => void
@@ -101,7 +106,7 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
   )
 
   const addDeleteKeys = React.useCallback(
-    (keys: string[], bucketName: string, prefix?: string, options?: { forceDelete?: boolean }) => {
+    (keys: string[], bucketName: string, prefix?: string, options?: { deleteAllVersions?: boolean }) => {
       if (!managerState) return
       const { manager, deleteHelpers } = managerState
       const newTasks = deleteHelpers.createTasks(keys, bucketName, prefix, options)

--- a/lib/delete-task.ts
+++ b/lib/delete-task.ts
@@ -17,7 +17,7 @@ export interface DeleteTask extends ManagedTask<DeleteStatus> {
   bucketName: string
   prefix?: string
   versionId?: string
-  forceDelete?: boolean
+  deleteAllVersions?: boolean
   actionLabel: string
   displayName: string
   subInfo: string
@@ -47,13 +47,12 @@ export interface DeleteTaskHelpers {
     keys: string[],
     bucketName: string,
     prefix?: string,
-    options?: { forceDelete?: boolean },
+    options?: { deleteAllVersions?: boolean },
   ) => DeleteTask[]
   createVersionedTasks: (
     items: { key: string; versionId?: string }[],
     bucketName: string,
     prefix?: string,
-    options?: { forceDelete?: boolean },
   ) => DeleteTask[]
   createFolderDeleteTask: (prefix: string, bucketName: string, options?: { forceDelete?: boolean }) => FolderDeleteTask
 }
@@ -73,7 +72,7 @@ function assertDeleteObjectsSucceeded(errors: { Key?: string; Code?: string; Mes
   throw new Error(first?.Message || first?.Code || `Failed to delete ${errors.length} object(s)${target}`)
 }
 
-function attachForceDeleteHeader(command: DeleteObjectCommand | DeleteObjectsCommand) {
+function attachForceDeleteHeader(command: DeleteObjectCommand) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(command.middlewareStack.add as any)(
     (next: (args: unknown) => Promise<unknown>) => async (args: { request?: { headers?: Record<string, string> } }) => {
@@ -91,17 +90,60 @@ export function createDeleteTaskHelpers(s3Client: S3Client, config: DeleteTaskCo
   const retryDelay = config.retryDelay ?? 1000
 
   const perform: TaskHandler<DeleteTask>["perform"] = async (task) => {
-    const { key, bucketName, prefix, versionId, forceDelete } = task
+    const { key, bucketName, prefix, versionId, deleteAllVersions } = task
     const abortController = new AbortController()
     task.abortController = abortController
+
+    if (deleteAllVersions && !versionId) {
+      // The recursive extension also covers child keys. A file selection must
+      // delete only the versions listed for this exact key, including markers.
+      const objectKey = (prefix ?? "") + key
+      const versions: { Key: string; VersionId: string }[] = []
+      let keyMarker: string | undefined
+      let versionIdMarker: string | undefined
+      while (true) {
+        const data = await s3Client.send(
+          new ListObjectVersionsCommand({
+            Bucket: bucketName,
+            Prefix: objectKey,
+            KeyMarker: keyMarker,
+            VersionIdMarker: versionIdMarker,
+            EncodingType: "url",
+          }),
+          { abortSignal: abortController.signal },
+        )
+        decodeS3UrlEncodedObjectVersions(data)
+        for (const version of [...(data.Versions ?? []), ...(data.DeleteMarkers ?? [])]) {
+          if (version.Key !== objectKey) continue
+          if (!version.VersionId) throw new Error("Object version listing did not return a version ID")
+          versions.push({ Key: objectKey, VersionId: version.VersionId })
+        }
+        if (!data.IsTruncated || (data.NextKeyMarker && data.NextKeyMarker !== objectKey)) break
+        if (!data.NextKeyMarker || (data.NextKeyMarker === keyMarker && data.NextVersionIdMarker === versionIdMarker)) {
+          throw new Error("Object version listing did not advance")
+        }
+        keyMarker = data.NextKeyMarker
+        versionIdMarker = data.NextVersionIdMarker
+      }
+      for (let offset = 0; offset < versions.length; offset += 1000) {
+        const result = await s3Client.send(
+          new DeleteObjectsCommand({
+            Bucket: bucketName,
+            Delete: { Objects: versions.slice(offset, offset + 1000), Quiet: true },
+          }),
+          { abortSignal: abortController.signal },
+        )
+        assertDeleteObjectsSucceeded(result.Errors)
+      }
+      task.progress = 100
+      return
+    }
 
     const command = new DeleteObjectCommand({
       Bucket: bucketName,
       Key: (prefix ?? "") + key,
       ...(versionId ? { VersionId: versionId } : {}),
     })
-
-    if (forceDelete) attachForceDeleteHeader(command)
 
     await s3Client.send(command, { abortSignal: abortController.signal })
     task.progress = 100
@@ -113,45 +155,9 @@ export function createDeleteTaskHelpers(s3Client: S3Client, config: DeleteTaskCo
     task.abortController = abortController
 
     if (forceDelete) {
-      let isTruncated = true
-      let keyMarker: string | undefined
-      let versionIdMarker: string | undefined
-
-      while (isTruncated) {
-        const data = await s3Client.send(
-          new ListObjectVersionsCommand({
-            Bucket: bucketName,
-            Prefix: prefix,
-            KeyMarker: keyMarker,
-            VersionIdMarker: versionIdMarker,
-            EncodingType: "url",
-          }),
-          { abortSignal: abortController.signal },
-        )
-        decodeS3UrlEncodedObjectVersions(data)
-
-        const objectsToDelete: { Key: string; VersionId?: string }[] = []
-        data.Versions?.forEach((v) => {
-          if (v.Key) objectsToDelete.push({ Key: v.Key, VersionId: v.VersionId })
-        })
-        data.DeleteMarkers?.forEach((m) => {
-          if (m.Key) objectsToDelete.push({ Key: m.Key, VersionId: m.VersionId })
-        })
-
-        if (objectsToDelete.length > 0) {
-          const command = new DeleteObjectsCommand({
-            Bucket: bucketName,
-            Delete: { Objects: objectsToDelete, Quiet: true },
-          })
-          attachForceDeleteHeader(command)
-          const result = await s3Client.send(command, { abortSignal: abortController.signal })
-          assertDeleteObjectsSucceeded(result.Errors)
-        }
-
-        isTruncated = data.IsTruncated ?? false
-        keyMarker = data.NextKeyMarker
-        versionIdMarker = data.NextVersionIdMarker
-      }
+      const command = new DeleteObjectCommand({ Bucket: bucketName, Key: prefix })
+      attachForceDeleteHeader(command)
+      await s3Client.send(command, { abortSignal: abortController.signal })
     } else {
       let isTruncated = true
       let continuationToken: string | undefined
@@ -189,9 +195,21 @@ export function createDeleteTaskHelpers(s3Client: S3Client, config: DeleteTaskCo
   const shouldRetry = (task: DeleteTask | FolderDeleteTask, error: unknown) => {
     if (task.status === lifecycle.canceled) return false
     if ((task.retryCount ?? 0) >= maxRetries) return false
-    const errorMessage = String((error as Error)?.message ?? "").toLowerCase()
-    const nonRetryableErrors = ["access denied", "forbidden", "invalid credentials", "bucket not found", "no such key"]
-    return !nonRetryableErrors.some((msg) => errorMessage.includes(msg))
+    const errorRecord = error as { name?: unknown; code?: unknown; Code?: unknown; message?: unknown }
+    const errorText = [errorRecord?.name, errorRecord?.code, errorRecord?.Code, errorRecord?.message]
+      .filter((value): value is string => typeof value === "string")
+      .join(" ")
+      .toLowerCase()
+      .replace(/[\s_-]+/g, "")
+    const nonRetryableErrors = [
+      "accessdenied",
+      "forbidden",
+      "invalidcredentials",
+      "bucketnotfound",
+      "nosuchbucket",
+      "nosuchkey",
+    ]
+    return !nonRetryableErrors.some((code) => errorText.includes(code))
   }
 
   const handler: TaskHandler<DeleteTask> = {
@@ -215,7 +233,7 @@ export function createDeleteTaskHelpers(s3Client: S3Client, config: DeleteTaskCo
   }
 
   const createTasksFromItems = (
-    items: { key: string; versionId?: string; forceDelete?: boolean }[],
+    items: { key: string; versionId?: string; deleteAllVersions?: boolean }[],
     bucketName: string,
     prefix?: string,
   ): DeleteTask[] =>
@@ -224,7 +242,7 @@ export function createDeleteTaskHelpers(s3Client: S3Client, config: DeleteTaskCo
       kind: "delete" as const,
       key: item.key,
       versionId: item.versionId,
-      forceDelete: item.forceDelete,
+      deleteAllVersions: item.deleteAllVersions,
       status: lifecycle.pending,
       progress: 0,
       bucketName,
@@ -237,24 +255,20 @@ export function createDeleteTaskHelpers(s3Client: S3Client, config: DeleteTaskCo
       retryCount: 0,
     }))
 
-  const createTasks = (keys: string[], bucketName: string, prefix?: string, options?: { forceDelete?: boolean }) =>
+  const createTasks = (
+    keys: string[],
+    bucketName: string,
+    prefix?: string,
+    options?: { deleteAllVersions?: boolean },
+  ) =>
     createTasksFromItems(
-      keys.map((key) => ({ key, forceDelete: options?.forceDelete })),
+      keys.map((key) => ({ key, deleteAllVersions: options?.deleteAllVersions })),
       bucketName,
       prefix,
     )
 
-  const createVersionedTasks = (
-    items: { key: string; versionId?: string }[],
-    bucketName: string,
-    prefix?: string,
-    options?: { forceDelete?: boolean },
-  ) =>
-    createTasksFromItems(
-      items.map((item) => ({ ...item, forceDelete: options?.forceDelete })),
-      bucketName,
-      prefix,
-    )
+  const createVersionedTasks = (items: { key: string; versionId?: string }[], bucketName: string, prefix?: string) =>
+    createTasksFromItems(items, bucketName, prefix)
 
   const createFolderDeleteTask = (
     prefix: string,

--- a/lib/object-delete.ts
+++ b/lib/object-delete.ts
@@ -8,6 +8,6 @@ export function shouldShowDeleteAllVersions(state: BucketVersioningState): boole
   return state === "enabled"
 }
 
-export function shouldForceDeleteObjects(state: BucketVersioningState, deleteAllVersions: boolean): boolean {
+export function shouldDeleteAllVersions(state: BucketVersioningState, deleteAllVersions: boolean): boolean {
   return state === "enabled" && deleteAllVersions
 }

--- a/lib/object-delete.ts
+++ b/lib/object-delete.ts
@@ -9,13 +9,5 @@ export function shouldShowDeleteAllVersions(state: BucketVersioningState): boole
 }
 
 export function shouldForceDeleteObjects(state: BucketVersioningState, deleteAllVersions: boolean): boolean {
-  if (state === "unknown") {
-    return false
-  }
-
-  if (state === "enabled") {
-    return deleteAllVersions
-  }
-
-  return true
+  return state === "enabled" && deleteAllVersions
 }

--- a/tests/lib/delete-task.test.ts
+++ b/tests/lib/delete-task.test.ts
@@ -1,15 +1,23 @@
 import test from "node:test"
 import assert from "node:assert/strict"
-import { DeleteObjectsCommand, ListObjectsV2Command, S3Client } from "@aws-sdk/client-s3"
+import { DeleteObjectsCommand, ListObjectsV2Command, ListObjectVersionsCommand, S3Client } from "@aws-sdk/client-s3"
 import type { HttpRequest } from "@aws-sdk/types"
-import { createDeleteTaskHelpers } from "../../lib/delete-task"
-import { resolveBucketVersioningState, shouldForceDeleteObjects } from "../../lib/object-delete"
+import { createDeleteTaskHelpers, type DeleteTask } from "../../lib/delete-task"
+import { resolveBucketVersioningState, shouldDeleteAllVersions } from "../../lib/object-delete"
+import { TaskManager } from "../../lib/task-manager"
+
+async function waitForTaskStatus(task: DeleteTask, status: DeleteTask["status"]) {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (task.status === status) return
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  assert.fail(`Timed out waiting for delete task to become ${status}`)
+}
 
 for (const [name, status, deleteAllVersions, expectedForceDelete] of [
   ["unversioned object", undefined, false, false],
   ["versioning-suspended object", "Suspended", false, false],
   ["versioned object", "Enabled", false, false],
-  ["explicit all-versions", "Enabled", true, true],
 ] as const) {
   test(`${name} deletion serializes the selected delete mode`, async (t) => {
     const requests: { method: string; path: string; headers: Record<string, string> }[] = []
@@ -28,7 +36,7 @@ for (const [name, status, deleteAllVersions, expectedForceDelete] of [
     t.after(() => client.destroy())
     const { handler, createTasks } = createDeleteTaskHelpers(client)
     const [task] = createTasks(["report.txt"], "test-bucket", "folder/", {
-      forceDelete: shouldForceDeleteObjects(resolveBucketVersioningState(status), deleteAllVersions),
+      deleteAllVersions: shouldDeleteAllVersions(resolveBucketVersioningState(status), deleteAllVersions),
     })
 
     await handler.perform(task)
@@ -46,6 +54,153 @@ for (const [name, status, deleteAllVersions, expectedForceDelete] of [
     assert.equal(task.progress, 100)
   })
 }
+
+test("all-version file deletion paginates exact versions and markers without deleting colliding keys", async (t) => {
+  const key = "folder/空间/%2F.txt"
+  const encodedKey = encodeURIComponent(key)
+  const requests: HttpRequest[] = []
+  const deletedBatches: string[][] = []
+  let listCalls = 0
+  const client = new S3Client({
+    region: "us-east-1",
+    endpoint: "http://127.0.0.1:9000",
+    forcePathStyle: true,
+    credentials: { accessKeyId: "test", secretAccessKey: "test" },
+    requestHandler: {
+      async handle(request: HttpRequest) {
+        requests.push(request)
+        assert.equal(
+          Object.keys(request.headers).some((name) => /^(x-rustfs|x-minio)-force-delete$/i.test(name)),
+          false,
+        )
+        let body: string
+        if (request.method === "GET") {
+          assert.equal(request.query?.prefix, key)
+          assert.equal(request.query?.versions, "")
+          listCalls++
+          if (listCalls === 1) {
+            body = `<ListVersionsResult><EncodingType>url</EncodingType><IsTruncated>true</IsTruncated><NextKeyMarker>${encodedKey}</NextKeyMarker><NextVersionIdMarker>v999</NextVersionIdMarker>${Array.from({ length: 1000 }, (_, i) => `<Version><Key>${encodedKey}</Key><VersionId>v${i}</VersionId></Version>`).join("")}</ListVersionsResult>`
+          } else {
+            assert.equal(listCalls, 2)
+            assert.equal(request.query?.["key-marker"], key)
+            assert.equal(request.query?.["version-id-marker"], "v999")
+            body = `<ListVersionsResult><EncodingType>url</EncodingType><IsTruncated>true</IsTruncated><NextKeyMarker>${encodedKey}%2Fchild</NextKeyMarker><Version><Key>${encodedKey}</Key><VersionId>null</VersionId></Version><DeleteMarker><Key>${encodedKey}</Key><VersionId>marker</VersionId></DeleteMarker><Version><Key>${encodedKey}%2Fchild</Key><VersionId>child-version</VersionId></Version><Version><Key>${encodedKey}-sibling</Key><VersionId>sibling-version</VersionId></Version></ListVersionsResult>`
+          }
+        } else {
+          assert.equal(request.method, "POST")
+          assert.equal(listCalls, 2, "enumeration finishes before any version is removed")
+          const xml = String(request.body)
+          const keys = [...xml.matchAll(/<Key>(.*?)<\/Key>/g)].map((match) => match[1])
+          assert.ok(keys.every((value) => value === key))
+          deletedBatches.push([...xml.matchAll(/<VersionId>(.*?)<\/VersionId>/g)].map((match) => match[1]))
+          body = "<DeleteResult/>"
+        }
+        return { response: { statusCode: 200, headers: {}, body: new TextEncoder().encode(body) } }
+      },
+    },
+  })
+  t.after(() => client.destroy())
+  const { handler, createTasks } = createDeleteTaskHelpers(client)
+  const [task] = createTasks([key], "test-bucket", undefined, { deleteAllVersions: true })
+
+  await handler.perform(task)
+
+  assert.deepEqual(
+    requests.map((request) => request.method),
+    ["GET", "GET", "POST", "POST"],
+  )
+  assert.deepEqual(deletedBatches, [Array.from({ length: 1000 }, (_, i) => `v${i}`), ["null", "marker"]])
+  assert.equal(task.progress, 100)
+})
+
+test("an explicit version selection never uses the recursive extension", async (t) => {
+  const requests: HttpRequest[] = []
+  const client = new S3Client({
+    region: "us-east-1",
+    endpoint: "http://127.0.0.1:9000",
+    forcePathStyle: true,
+    credentials: { accessKeyId: "test", secretAccessKey: "test" },
+    requestHandler: {
+      async handle(request: HttpRequest) {
+        requests.push(request)
+        return { response: { statusCode: 204, headers: {}, body: new Uint8Array() } }
+      },
+    },
+  })
+  t.after(() => client.destroy())
+  const { handler, createVersionedTasks } = createDeleteTaskHelpers(client)
+  const [task] = createVersionedTasks([{ key: "file.txt", versionId: "null" }], "test-bucket")
+  await handler.perform(task)
+  assert.equal(requests.length, 1)
+  assert.equal(requests[0].method, "DELETE")
+  assert.equal(requests[0].query?.versionId, "null")
+  assert.equal(
+    Object.keys(requests[0].headers).some((name) => /force-delete/i.test(name)),
+    false,
+  )
+})
+
+test("all-version file deletion reports partial failures", async () => {
+  const client = {
+    send: async (command: unknown) => {
+      if (command instanceof ListObjectVersionsCommand) {
+        return { Versions: [{ Key: "file.txt", VersionId: "protected" }] }
+      }
+      assert.ok(command instanceof DeleteObjectsCommand)
+      return { Errors: [{ Key: "file.txt", VersionId: "protected", Code: "AccessDenied" }] }
+    },
+  }
+  const { handler, createTasks } = createDeleteTaskHelpers(client as unknown as S3Client)
+  const [task] = createTasks(["file.txt"], "test-bucket", undefined, { deleteAllVersions: true })
+  await assert.rejects(handler.perform(task), /AccessDenied/)
+  assert.equal(task.progress, 0)
+})
+
+test("AccessDenied from version deletion fails without retrying", async (t) => {
+  let deleteAttempts = 0
+  const client = {
+    send: async (command: unknown) => {
+      if (command instanceof ListObjectVersionsCommand) {
+        return { Versions: [{ Key: "file.txt", VersionId: "protected" }] }
+      }
+      assert.ok(command instanceof DeleteObjectsCommand)
+      deleteAttempts += 1
+      return { Errors: [{ Key: "file.txt", VersionId: "protected", Code: "AccessDenied" }] }
+    },
+  }
+  const { handler, createTasks } = createDeleteTaskHelpers(client as unknown as S3Client, {
+    maxRetries: 3,
+    retryDelay: 0,
+  })
+  const [task] = createTasks(["file.txt"], "test-bucket", undefined, { deleteAllVersions: true })
+  const manager = new TaskManager<DeleteTask>({ handlers: { delete: handler } })
+  t.after(() => manager.dispose())
+
+  manager.enqueue([task])
+  await waitForTaskStatus(task, "failed")
+
+  assert.equal(deleteAttempts, 1)
+  assert.equal(task.retryCount, 0)
+  assert.equal(task.error, "AccessDenied")
+})
+
+test("all-version file deletion fails before mutation when pagination does not advance", async () => {
+  const client = {
+    send: async (command: unknown) => {
+      assert.ok(command instanceof ListObjectVersionsCommand)
+      return {
+        Versions: [{ Key: "file.txt", VersionId: "v1" }],
+        IsTruncated: true,
+        NextKeyMarker: "file.txt",
+        NextVersionIdMarker: "v1",
+      }
+    },
+  }
+  const { handler, createTasks } = createDeleteTaskHelpers(client as unknown as S3Client)
+  const [task] = createTasks(["file.txt"], "test-bucket", undefined, { deleteAllVersions: true })
+  await assert.rejects(handler.perform(task), /did not advance/)
+  assert.equal(task.progress, 0)
+})
 
 for (const status of [undefined, "Suspended"]) {
   test(`ordinary folder deletion uses standard listing and batch deletion when versioning is ${status ?? "unset"}`, async (t) => {
@@ -86,7 +241,7 @@ for (const status of [undefined, "Suspended"]) {
     t.after(() => client.destroy())
     const { folderHandler, createFolderDeleteTask } = createDeleteTaskHelpers(client)
     const task = createFolderDeleteTask("folder/", "test-bucket", {
-      forceDelete: shouldForceDeleteObjects(resolveBucketVersioningState(status), false),
+      forceDelete: shouldDeleteAllVersions(resolveBucketVersioningState(status), false),
     })
 
     await folderHandler.perform(task)
@@ -95,6 +250,83 @@ for (const status of [undefined, "Suspended"]) {
     assert.equal(task.progress, 100)
   })
 }
+
+for (const statusCode of [204, 403]) {
+  test(`explicit all-versions folder deletion uses one prefix request and handles HTTP ${statusCode}`, async (t) => {
+    const requests: HttpRequest[] = []
+    const client = new S3Client({
+      region: "us-east-1",
+      endpoint: "http://127.0.0.1:9000",
+      forcePathStyle: true,
+      maxAttempts: 1,
+      credentials: { accessKeyId: "test", secretAccessKey: "test" },
+      requestHandler: {
+        async handle(request: HttpRequest) {
+          requests.push(request)
+          return {
+            response: {
+              statusCode,
+              headers: {},
+              body: new TextEncoder().encode(
+                statusCode === 403 ? "<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>" : "",
+              ),
+            },
+          }
+        },
+      },
+    })
+    t.after(() => client.destroy())
+    const { folderHandler, createFolderDeleteTask } = createDeleteTaskHelpers(client)
+    const task = createFolderDeleteTask("parent/空间/%2F+/", "test-bucket", { forceDelete: true })
+
+    if (statusCode === 403) {
+      await assert.rejects(folderHandler.perform(task), { name: "AccessDenied" })
+      assert.equal(task.progress, 0)
+    } else {
+      await folderHandler.perform(task)
+      assert.equal(task.progress, 100)
+    }
+    assert.equal(requests.length, 1)
+    assert.equal(requests[0].method, "DELETE")
+    assert.equal(requests[0].path, "/test-bucket/parent/%E7%A9%BA%E9%97%B4/%252F%2B/")
+    assert.equal(requests[0].headers["X-Rustfs-Force-Delete"], "true")
+    assert.equal(requests[0].query?.versionId, undefined)
+  })
+}
+
+test("canceling a forced folder deletion aborts its single request", async (t) => {
+  let requestStarted: () => void = () => {}
+  const started = new Promise<void>((resolve) => {
+    requestStarted = resolve
+  })
+  const client = new S3Client({
+    region: "us-east-1",
+    endpoint: "http://127.0.0.1:9000",
+    forcePathStyle: true,
+    maxAttempts: 1,
+    credentials: { accessKeyId: "test", secretAccessKey: "test" },
+    requestHandler: {
+      async handle(_request: HttpRequest, options?: { abortSignal?: AbortSignal }) {
+        assert.ok(options?.abortSignal)
+        requestStarted()
+        return new Promise<never>((_resolve, reject) => {
+          options.abortSignal?.addEventListener("abort", () => {
+            reject(Object.assign(new Error("Request aborted"), { name: "AbortError" }))
+          })
+        })
+      },
+    },
+  })
+  t.after(() => client.destroy())
+  const { folderHandler, createFolderDeleteTask } = createDeleteTaskHelpers(client)
+  const task = createFolderDeleteTask("folder/", "test-bucket", { forceDelete: true })
+  const pending = folderHandler.perform(task)
+  await started
+  task.abortController?.abort()
+
+  await assert.rejects(pending, { name: "AbortError" })
+  assert.equal(task.progress, 0)
+})
 
 test("folder deletion rejects partial DeleteObjects failures", async () => {
   const client = {

--- a/tests/lib/delete-task.test.ts
+++ b/tests/lib/delete-task.test.ts
@@ -1,7 +1,100 @@
 import test from "node:test"
 import assert from "node:assert/strict"
-import { DeleteObjectsCommand, ListObjectsV2Command, type S3Client } from "@aws-sdk/client-s3"
+import { DeleteObjectsCommand, ListObjectsV2Command, S3Client } from "@aws-sdk/client-s3"
+import type { HttpRequest } from "@aws-sdk/types"
 import { createDeleteTaskHelpers } from "../../lib/delete-task"
+import { resolveBucketVersioningState, shouldForceDeleteObjects } from "../../lib/object-delete"
+
+for (const [name, status, deleteAllVersions, expectedForceDelete] of [
+  ["unversioned object", undefined, false, false],
+  ["versioning-suspended object", "Suspended", false, false],
+  ["versioned object", "Enabled", false, false],
+  ["explicit all-versions", "Enabled", true, true],
+] as const) {
+  test(`${name} deletion serializes the selected delete mode`, async (t) => {
+    const requests: { method: string; path: string; headers: Record<string, string> }[] = []
+    const client = new S3Client({
+      region: "us-east-1",
+      endpoint: "http://127.0.0.1:9000",
+      forcePathStyle: true,
+      credentials: { accessKeyId: "test", secretAccessKey: "test" },
+      requestHandler: {
+        async handle(request: HttpRequest) {
+          requests.push(request)
+          return { response: { statusCode: 204, headers: {}, body: new Uint8Array() } }
+        },
+      },
+    })
+    t.after(() => client.destroy())
+    const { handler, createTasks } = createDeleteTaskHelpers(client)
+    const [task] = createTasks(["report.txt"], "test-bucket", "folder/", {
+      forceDelete: shouldForceDeleteObjects(resolveBucketVersioningState(status), deleteAllVersions),
+    })
+
+    await handler.perform(task)
+
+    assert.equal(requests.length, 1)
+    assert.equal(requests[0].method, "DELETE")
+    assert.equal(requests[0].path, "/test-bucket/folder/report.txt")
+    const forceDeleteHeaders = Object.entries(requests[0].headers).filter(([name]) =>
+      /^(x-rustfs|x-minio)-force-delete$/i.test(name),
+    )
+    assert.deepEqual(
+      forceDeleteHeaders.map(([, value]) => value),
+      expectedForceDelete ? ["true"] : [],
+    )
+    assert.equal(task.progress, 100)
+  })
+}
+
+for (const status of [undefined, "Suspended"]) {
+  test(`ordinary folder deletion uses standard listing and batch deletion when versioning is ${status ?? "unset"}`, async (t) => {
+    const methods: string[] = []
+    const client = new S3Client({
+      region: "us-east-1",
+      endpoint: "http://127.0.0.1:9000",
+      forcePathStyle: true,
+      credentials: { accessKeyId: "test", secretAccessKey: "test" },
+      requestHandler: {
+        async handle(request: HttpRequest) {
+          methods.push(request.method)
+          assert.equal(
+            Object.keys(request.headers).some((name) => /^(x-rustfs|x-minio)-force-delete$/i.test(name)),
+            false,
+          )
+          if (request.method === "GET") {
+            assert.equal(request.query?.["list-type"], "2")
+            assert.equal(request.query?.prefix, "folder/")
+            return {
+              response: {
+                statusCode: 200,
+                headers: {},
+                body: new TextEncoder().encode(
+                  "<ListBucketResult><IsTruncated>false</IsTruncated><Contents><Key>folder/report.txt</Key></Contents></ListBucketResult>",
+                ),
+              },
+            }
+          }
+          assert.equal(request.method, "POST")
+          assert.match(String(request.body), /<Key>folder\/report\.txt<\/Key>/)
+          return {
+            response: { statusCode: 200, headers: {}, body: new TextEncoder().encode("<DeleteResult/>") },
+          }
+        },
+      },
+    })
+    t.after(() => client.destroy())
+    const { folderHandler, createFolderDeleteTask } = createDeleteTaskHelpers(client)
+    const task = createFolderDeleteTask("folder/", "test-bucket", {
+      forceDelete: shouldForceDeleteObjects(resolveBucketVersioningState(status), false),
+    })
+
+    await folderHandler.perform(task)
+
+    assert.deepEqual(methods, ["GET", "POST"])
+    assert.equal(task.progress, 100)
+  })
+}
 
 test("folder deletion rejects partial DeleteObjects failures", async () => {
   const client = {

--- a/tests/lib/object-delete-safety.test.js
+++ b/tests/lib/object-delete-safety.test.js
@@ -13,7 +13,7 @@ test("unknown bucket versioning state never enables force delete", () => {
   assert.equal(resolveBucketVersioningState("Enabled"), "enabled")
   assert.equal(shouldShowDeleteAllVersions("unknown"), false)
   assert.equal(shouldForceDeleteObjects("unknown", false), false)
-  assert.equal(shouldForceDeleteObjects("disabled", false), true)
+  assert.equal(shouldForceDeleteObjects("disabled", false), false)
 })
 
 test("object deletion stays blocked until versioning state is known", () => {

--- a/tests/lib/object-delete-safety.test.js
+++ b/tests/lib/object-delete-safety.test.js
@@ -3,17 +3,17 @@ import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
 import {
   resolveBucketVersioningState,
-  shouldForceDeleteObjects,
+  shouldDeleteAllVersions,
   shouldShowDeleteAllVersions,
 } from "../../lib/object-delete.ts"
 
 const objectListSource = await readFile(new URL("../../components/object/list.tsx", import.meta.url), "utf8")
 
-test("unknown bucket versioning state never enables force delete", () => {
+test("unknown bucket versioning state never enables all-version deletion", () => {
   assert.equal(resolveBucketVersioningState("Enabled"), "enabled")
   assert.equal(shouldShowDeleteAllVersions("unknown"), false)
-  assert.equal(shouldForceDeleteObjects("unknown", false), false)
-  assert.equal(shouldForceDeleteObjects("disabled", false), false)
+  assert.equal(shouldDeleteAllVersions("unknown", false), false)
+  assert.equal(shouldDeleteAllVersions("disabled", false), false)
 })
 
 test("object deletion stays blocked until versioning state is known", () => {

--- a/tests/lib/object-delete.test.ts
+++ b/tests/lib/object-delete.test.ts
@@ -19,8 +19,17 @@ test("shouldShowDeleteAllVersions only shows the option for enabled buckets", ()
 })
 
 test("shouldForceDeleteObjects never force deletes while versioning state is unknown", () => {
-  assert.equal(shouldForceDeleteObjects("enabled", true), true)
-  assert.equal(shouldForceDeleteObjects("enabled", false), false)
-  assert.equal(shouldForceDeleteObjects("disabled", false), true)
   assert.equal(shouldForceDeleteObjects("unknown", false), false)
+  assert.equal(shouldForceDeleteObjects("unknown", true), false)
+})
+
+test("ordinary object deletion never requests recursive force delete", () => {
+  for (const status of [undefined, "Suspended", "Enabled"]) {
+    assert.equal(shouldForceDeleteObjects(resolveBucketVersioningState(status), false), false)
+  }
+})
+
+test("force delete requires an explicit all-versions selection in an enabled bucket", () => {
+  assert.equal(shouldForceDeleteObjects("enabled", true), true)
+  assert.equal(shouldForceDeleteObjects("disabled", true), false)
 })

--- a/tests/lib/object-delete.test.ts
+++ b/tests/lib/object-delete.test.ts
@@ -2,7 +2,7 @@ import test from "node:test"
 import assert from "node:assert/strict"
 import {
   resolveBucketVersioningState,
-  shouldForceDeleteObjects,
+  shouldDeleteAllVersions,
   shouldShowDeleteAllVersions,
 } from "../../lib/object-delete"
 
@@ -18,18 +18,18 @@ test("shouldShowDeleteAllVersions only shows the option for enabled buckets", ()
   assert.equal(shouldShowDeleteAllVersions("unknown"), false)
 })
 
-test("shouldForceDeleteObjects never force deletes while versioning state is unknown", () => {
-  assert.equal(shouldForceDeleteObjects("unknown", false), false)
-  assert.equal(shouldForceDeleteObjects("unknown", true), false)
+test("shouldDeleteAllVersions stays disabled while versioning state is unknown", () => {
+  assert.equal(shouldDeleteAllVersions("unknown", false), false)
+  assert.equal(shouldDeleteAllVersions("unknown", true), false)
 })
 
 test("ordinary object deletion never requests recursive force delete", () => {
   for (const status of [undefined, "Suspended", "Enabled"]) {
-    assert.equal(shouldForceDeleteObjects(resolveBucketVersioningState(status), false), false)
+    assert.equal(shouldDeleteAllVersions(resolveBucketVersioningState(status), false), false)
   }
 })
 
-test("force delete requires an explicit all-versions selection in an enabled bucket", () => {
-  assert.equal(shouldForceDeleteObjects("enabled", true), true)
-  assert.equal(shouldForceDeleteObjects("disabled", true), false)
+test("all-version deletion requires an explicit selection in an enabled bucket", () => {
+  assert.equal(shouldDeleteAllVersions("enabled", true), true)
+  assert.equal(shouldDeleteAllVersions("disabled", true), false)
 })


### PR DESCRIPTION
# Pull Request

## Description

Console object deletion could attach `X-Rustfs-Force-Delete: true` to requests that should have used ordinary S3 deletion semantics. The header is a RustFS recursive-delete extension, so using it for a selected file could require elevated handling and expand the operation beyond the exact object key.

This change keeps the extension for folder-wide **Delete All Versions** tasks while making every ordinary SDK path S3-compatible:

- ordinary files use `DeleteObject`, with `VersionId` only when the user selected a concrete version;
- a file-level **Delete All Versions** task exhausts `ListObjectVersions`, keeps only the exact key, and sends explicit version IDs through `DeleteObjects` in batches of at most 1000;
- ordinary folders retain the existing `ListObjectsV2` plus `DeleteObjects` flow;
- only folder-wide all-version deletion attaches the RustFS force-delete header.

Version and delete-marker enumeration completes before mutation starts, pagination must advance, and partial `DeleteObjects` failures surface immediately.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test improvements
- [ ] Security fix

## Testing

- [x] Unit tests added/updated
- [x] Manual testing completed

Passed with Node.js 22.22.0 and the pinned pnpm 12.3.4:

```bash
pnpm install --frozen-lockfile
pnpm type-check
pnpm lint
pnpm format:check
pnpm test:run
git diff --check
```

All 583 tests pass. Focused regression coverage verifies exact-key filtering across versions and delete markers, `null` versions, 1000-item batching, 1001-item pagination, non-advancing pagination rejection, partial batch errors, explicit version deletion, ordinary folder behavior, force-header isolation, and cancellation.

Browser verification used a disposable RustFS backend at commit `4c2ba0896` and the same non-root `consoleAdmin` user before and after. Single-object deletion changed from HTTP 403 with the force header to HTTP 204 without it. The selected object disappeared and its similarly prefixed sibling remained. Folder deletion also completed at a 390px viewport using standard requests. Independent API probes confirmed that a readonly user is still denied, neighboring prefixes remain intact, and ordinary deletes preserve historical versions in enabled and suspended buckets.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] TypeScript types are properly defined
- [x] All commit messages are in English (Conventional Commits)
- [x] All existing tests pass
- [x] No new dependencies added, or they are justified

## Related Issues

Fixes rustfs/rustfs#7649

## Screenshots (if applicable)

Desktop captures show the same object deletion with the same IAM user and backend at 1280 x 720.

| Before: failed | After: completed |
| --- | --- |
| ![Before: ordinary object deletion fails](https://github.com/user-attachments/assets/7ec1ac94-a991-48e7-af16-5f403baba2ff) | ![After: ordinary object deletion succeeds](https://github.com/user-attachments/assets/66f02ff0-14a7-45c8-927c-0e248129bd85) |

<details>
<summary>390px viewport: object and folder deletion completed</summary>

![Mobile deletion results](https://github.com/user-attachments/assets/b196603f-854c-4a54-b441-c00d35e4cb85)

</details>

## Additional Notes

The RustFS force-delete extension remains available for a folder-wide all-version operation; SDK users and other S3 clients continue to use standard request shapes. Independent Reviewer and Simplifier passes found no issues in the final behavior or test coverage.

Rollback is a revert of these Console commits. No API, storage, configuration, or data migration is required.
